### PR TITLE
Copy tokens from Kubernetes to the Secret Manager.

### DIFF
--- a/tokens/README.md
+++ b/tokens/README.md
@@ -1,0 +1,25 @@
+Copies the authentication tokens for Hail Batch service accounts from
+Kubernetes secrets to the Secret Manager. There it is accessible by the server
+that launches Batch pipelines on behalf of users.
+
+In order to run this, you must have access to the Kubernetes cluster:
+
+```batch
+gcloud container clusters get-credentials vdc
+```
+
+Install the Python dependencies using a conda environment:
+
+```batch
+conda create --name analysis-tokens python=3.9.0
+conda activate analysis-tokens
+pip install kubernetes==12.0.1 google-cloud-secret-manager==2.2.0 
+```
+
+The list of projects is hardcoded in `main.py`. To update the secret stored in
+Secret Manager:
+
+```batch
+gcloud config set project analysis-runner
+python3 main.py
+```

--- a/tokens/main.py
+++ b/tokens/main.py
@@ -1,0 +1,28 @@
+import json
+from kubernetes import client, config
+from google.cloud import secretmanager
+
+PROJECTS = [
+    'tob-wgs',
+]
+
+GCP_PROJECT = 'analysis-runner'
+SECRET_MANAGER_SECRET_NAME = 'hail-tokens'
+
+config.load_kube_config()
+kube_client = client.CoreV1Api()
+
+tokens = {}
+for project in PROJECTS:
+    secret_name = f'{project}-tokens'
+    secret = kube_client.read_namespaced_secret(secret_name, 'default')
+    tokens[project] = secret.data['tokens.json']
+
+secret_manager = secretmanager.SecretManagerServiceClient()
+payload = json.dumps(tokens).encode('UTF-8')
+parent = secret_manager.secret_path(GCP_PROJECT, SECRET_MANAGER_SECRET_NAME)
+response = secret_manager.add_secret_version(
+    request={"parent": parent, "payload": {"data": payload}}
+)
+
+print(f'Added secret version: {response.name}')


### PR DESCRIPTION
There's still a lot of functionality missing overall, but I prefer sending a number of smaller PRs.