### PR TITLE
Remove general exception catchers in server

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -181,12 +181,6 @@ async def index(request):
     except KeyError as e:
         logging.error(e)
         raise web.HTTPBadRequest(reason='Missing request parameter')
-    # Handle and rethrow KeyboardInterrupt error to stop global exception catch
-    except KeyboardInterrupt:  # pylint: disable=try-except-raise
-        raise
-    except Exception as e:
-        logging.error(e)
-        raise web.HTTPServerError(reason=str(e))
 
 
 async def init_func():


### PR DESCRIPTION
Otherwise, HTTPForbidden messages etc. don't get returned to the client.