### PR TITLE
Update driver image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Since the server relies on Hail as well, we're reusing the driver image.
-FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:f2fc08ff8c5e'
+FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:783bfdcb78f4'
 
 RUN conda install -c conda-forge google-auth==1.24.0 google-cloud-secret-manager==2.2.0 google-cloud-pubsub==2.3.0 gunicorn
 

--- a/server/main.py
+++ b/server/main.py
@@ -19,7 +19,7 @@ ALLOWED_REPOS = {
 }
 
 DRIVER_IMAGE = (
-    'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:ffc8144b0e1e'
+    'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:783bfdcb78f4'
 )
 
 # The GCP_PROJECT is the project ID, not the project name, and is therefore sometimes


### PR DESCRIPTION
I've released a new version of the driver image based on changes in https://github.com/populationgenomics/analysis-runner/pull/27.

It's probably worth merging https://github.com/populationgenomics/analysis-runner/pull/28 before a new server version is actually built and deployed.