### PR TITLE
Check permission groups explicitly, allowing for extended access

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,6 +25,6 @@ max-line-length=88
 
 [DESIGN]
 # Maximum number of locals for function / method body
-max-locals=25
+max-locals=30
 # Maximum number of arguments for function / method
 max-args=10

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,50 +8,50 @@ There are two ways to run the analysis-runner CLI: with the `--repository` param
 
 1. Omitting the `--repository` parameter: use the repository of the local directory that you're in: (a) get the repository name from the git remote; (b) use the commit of HEAD (if the `--commit` parameter is omitted); (c) Make the script path relative to the root of the git repository.
 
-  ```bash
-  # cwd is the git directory root
-  cd path/to/script
-  analysis-runner \
-      --dataset <dataset> \
-      --description "Description of the run" \
-      --output-dir gs://<bucket> \
-      main.py and some arguments # becomes path/to/script/main.py and some arguments
-  ```
+```bash
+# cwd is the git directory root
+cd path/to/script
+analysis-runner \
+    --dataset <dataset> \
+    --description "Description of the run" \
+    --output-dir gs://<bucket> \
+    main.py and some arguments # becomes path/to/script/main.py and some arguments
+```
 
 1. Providing the `--repository` parameter, making the script path relative to the git repository is disabled, and you must provide a commit hash too. For example:
 
-  ```bash
-  # You must specify relative path from git root to script
-  analysis-runner \
-      --dataset <dataset> \
-      --description "Description of the run" \
-      --output-dir gs://<bucket> \
-      --repository <repository> \
-      --commit <hash> \
-      path/to/script/main.py and some arguments
-  ```
+```bash
+# You must specify relative path from git root to script
+analysis-runner \
+    --dataset <dataset> \
+    --description "Description of the run" \
+    --output-dir gs://<bucket> \
+    --repository <repository> \
+    --commit <hash> \
+    path/to/script/main.py and some arguments
+```
 
 ## CLI Overview
 
 Process:
 
 1. Fill in the mising info (repository, commit hash)
-2. Get the gcloud auth token
-    * `gcloud auth print-identity-token`
-    * `google.auth.default()[0].id_token` (after credentials refresh)
-3. Get the submit URL from the `dataset` parameter
-    * Do this by looking up a JSON map from `servermap.json` (in this repo)
-4. Form a POST request with params:
-    * output
-    * repo
-    * commit
-    * script
-    * description
-5. Collect and print response
+1. Get the gcloud auth token
+   - `gcloud auth print-identity-token`
+   - `google.auth.default()[0].id_token` (after credentials refresh)
+1. Form a POST request with params:
+   - dataset
+   - output
+   - repo
+   - extendedAccess
+   - commit
+   - script
+   - description
+1. Collect and print response
 
 ## Requirements
 
 These packages are pinned to specific versions in the `conda/analysis-runner/meta.yaml` config.
 
-* `click` for the command line
-* `google-auth` to request the identity token
+- `click` for the command line
+- `google-auth` to request the identity token

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -61,7 +61,8 @@ SUPPORTED_ORGANIZATIONS = {'populationgenomics'}
     help='Description of job, otherwise defaults to: "$USER FROM LOCAL: $REPO@$COMMIT"',
 )
 @click.option(
-    '--extended-access', help='Whether to use the extended-access permissions group.'
+    '--extended-access/--no-extended-access',
+    help='Whether to use the extended-access permissions group.',
 )
 @click.argument('script', nargs=-1)
 def main(

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -17,10 +17,9 @@ from cli import _version
 logging.basicConfig(level='INFO')
 
 BRANCH = 'main'
-DEFAULT_SERVER_LOOKUP = (
-    f'https://raw.githubusercontent.com/'
-    f'populationgenomics/analysis-runner/{BRANCH}/cli/servermap.json'
-)
+
+SERVER_ENDPOINT = 'https://server-a2pko7ameq-ts.a.run.app'
+
 # Make this None if you want to support all organizations
 SUPPORTED_ORGANIZATIONS = {'populationgenomics'}
 
@@ -61,8 +60,19 @@ SUPPORTED_ORGANIZATIONS = {'populationgenomics'}
     required=True,
     help='Description of job, otherwise defaults to: "$USER FROM LOCAL: $REPO@$COMMIT"',
 )
+@click.option(
+    '--extended-access', help='Whether to use the extended-access permissions group.'
+)
 @click.argument('script', nargs=-1)
-def main(dataset, output_dir, script, description, commit=None, repository=None):
+def main(
+    dataset,
+    output_dir,
+    script,
+    description,
+    commit=None,
+    repository=None,
+    extended_access=False,
+):
     """
     Main function that drives the CLI.
     The parameters are provided automatically by @click.
@@ -91,16 +101,17 @@ def main(dataset, output_dir, script, description, commit=None, repository=None)
         # to the git root and current directory
         _script[0] = _get_relative_script_path_from_git_root(_script[0])
 
-    _url = _get_url_from_dataset(dataset)
     _token = _get_google_auth_token()
 
     logging.info(f'Submitting {_repository}@{_commit_ref} for dataset "{dataset}"')
 
     response = requests.post(
-        _url,
+        SERVER_ENDPOINT,
         json={
+            'dataset': dataset,
             'output': output_dir,
             'repo': _repository,
+            'extendedAccess': extended_access,
             'commit': _commit_ref,
             'script': _script,
             'description': description,
@@ -207,20 +218,6 @@ def _get_repo_name_from_remote(remote_name: str) -> str:
         repo = repo[:-4]
 
     return repo
-
-
-def _get_url_from_dataset(dataset: str) -> str:
-    resource = requests.get(DEFAULT_SERVER_LOOKUP)
-    if not resource.ok:
-        resource.raise_for_status()
-
-    d = resource.json()
-
-    url = d.get(dataset)
-    if url:
-        return url
-
-    raise Exception(f"Couldn't get URL for '{dataset}', expected one of {d.keys()}")
 
 
 if __name__ == '__main__':

--- a/cli/servermap.json
+++ b/cli/servermap.json
@@ -1,4 +1,0 @@
-{
-  "tob-wgs": "https://analysis-runner-server-9eddd6b-aceka37pgq-ts.a.run.app",
-  "fewgenomes": "https://analysis-runner-server-bc3254b-i5utivowgq-ts.a.run.app"
-}

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,6 +7,7 @@ dependencies:
   - black
   - flake8
   - flake8-bugbear
+  - google-api-python-client=1.12.8
   - google-auth=1.24.0
   - google-cloud-secret-manager=2.2.0
   - google-cloud-pubsub=2.3.0

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 # Since the server relies on Hail as well, we're reusing the driver image.
 FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:f2fc08ff8c5e'
 
-RUN conda install -c conda-forge google-auth==1.24.0 google-cloud-secret-manager==2.2.0 google-cloud-pubsub==2.3.0 gunicorn
+RUN conda install -c conda-forge google-api-python-client=1.12.8 google-auth==1.24.0 google-cloud-secret-manager==2.2.0 google-cloud-pubsub==2.3.0 gunicorn
 
 # Allow statements and log messages to immediately appear in the Knative logs.
 ENV PYTHONUNBUFFERED 1
@@ -9,6 +9,6 @@ ENV PYTHONUNBUFFERED 1
 ENV PORT 8080
 EXPOSE $PORT
 
-COPY main.py .
+COPY main.py cloud_identity.py ./
 
 CMD gunicorn --bind :$PORT --worker-class aiohttp.GunicornWebWorker main:init_func

--- a/server/README.md
+++ b/server/README.md
@@ -8,12 +8,7 @@ doesn't mix well with `flask`'s threads.
 
 Each dataset / [storage
 stack](https://github.com/populationgenomics/team-docs/tree/main/storage_policies)
-has its own Cloud Run deployment. This way, memberships in the respective
-permission groups (`$STACK-restricted-access@populationgenomics.org.au`)
-can be checked by assigning the _Cloud Run Invoker_ IAM role to the group.
-While there's also a Cloud Identity API to check group memberships, this
-feature unfortunately is [only available in Google Workspace Enterprise
-editions](https://googlecloudproject.com/identity/docs/reference/rest/v1/groups.memberships/checkTransitiveMembership).
+has its own permissions groups, which are checked through a single analysis-runner instance.
 
 To build a new Docker image for the server, run:
 
@@ -26,29 +21,30 @@ echo $COMMIT_HASH
 gcloud builds submit --timeout 1h --tag $IMAGE:$COMMIT_HASH
 ```
 
-Deployment is handled as part of the [Pulumi
-configuration](https://github.com/populationgenomics/team-docs/tree/main/storage_policies#automation),
-which references the `$COMMIT_HASH` in the Docker image reference.
+To deploy, run:
 
-Hail service account [tokens](../tokens) need to be copied to Secret Manager secrets
-separately, after the stack has been set up.
+```bash
+gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated \
+    --service-account analysis-runner-server@analysis-runner.iam.gserviceaccount.com \
+    --platform managed --image $IMAGE:$COMMIT_HASH
+```
 
-As the Cloud Run HTTPS deployment endpoint addresses seem to be unpredictable,
-they currently need to be added manually to the [CLI tool](../cli).
+Hail service account [tokens](../tokens) need to be copied to a Secret Manager secret
+separately, after the stacks have been set up.
+
+The Cloud Run HTTPS deployment endpoint is hardcoded in the [CLI tool](../cli).
 
 ## Testing locally
 
 See [Testing the Container Image Locally](https://cloud.google.com/run/docs/testing/local)
 for details.
 
-Download a JSON key for the `analysis-runner-server` service account for a `$DATASET`
-in its corresponding `$GCP_PROJECT`. Store the file name in the `$GSA_KEY_FILE`
-environment variable. Then run:
+Download a JSON key for the `analysis-runner-server` service account. Store the file name in the `$GSA_KEY_FILE` environment variable. Then run:
 
 ```bash
 docker build -t analysis-runner-server .
 
-docker run -it -p 8080:8080 -v $GSA_KEY_FILE:/gsa-key/key.json -e GCP_PROJECT=$GCP_PROJECT -e DATASET=$DATASET -e GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json analysis-runner-server
+docker run -it -p 8080:8080 -v $GSA_KEY_FILE:/gsa-key/key.json -e GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json analysis-runner-server
 ```
 
 This will start a server that listens locally on port 8080.
@@ -57,5 +53,5 @@ From another terminal, send a request like this, replacing the JSON parameters
 accordingly.
 
 ```bash
-TOKEN=$(gcloud auth print-identity-token) curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type:application/json" -d '{"output": "gs://test-bucket/test", "repo": "hail-batch-test", "commit": "0fa3abfe59692618578c4e1551b2a9357566d2ad", "script": ["main.py"], "description": "test"}' localhost:8080
+TOKEN=$(gcloud auth print-identity-token) curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type:application/json" -d '{"output": "gs://test-bucket/test", "dataset": "fewgenomes", "extendedAccess": false, "repo": "hail-batch-test", "commit": "0fa3abfe59692618578c4e1551b2a9357566d2ad", "script": ["main.py"], "description": "test"}' localhost:8080
 ```

--- a/server/cloud_identity.py
+++ b/server/cloud_identity.py
@@ -1,0 +1,42 @@
+"""Convenience functions for using the GCP Cloud Identity API."""
+
+import logging
+import googleapiclient.discovery
+
+SERVICE_NAME = 'cloudidentity.googleapis.com'
+API_VERSION = 'v1'
+DISCOVERY_URL = f'https://{SERVICE_NAME}/$discovery/rest?version={API_VERSION}'
+
+service = googleapiclient.discovery.build(
+    SERVICE_NAME, API_VERSION, discoveryServiceUrl=DISCOVERY_URL
+)
+
+
+def check_group_membership(user: str, group: str) -> bool:
+    """Returns whether the user is a member of the group.
+
+    Both user and group are specified as email addresses.
+
+    Note:
+    - This does *not* look up transitive memberships, i.e. nested groups.
+    - The service account performing the lookup must be a member of the group itself,
+      in order to have visiblity of all members.
+    """
+
+    try:
+        # See https://bit.ly/37WcB1d for the API calls.
+        # Pylint can't resolve the methods in Resource objects.
+        # pylint: disable=E1101
+        parent = service.groups().lookup(groupKey_id=group).execute()['name']
+
+        _ = (
+            service.groups()
+            .memberships()
+            .lookup(parent=parent, memberKey_id=user)
+            .execute()['name']
+        )
+
+        return True
+    except googleapiclient.errors.HttpError as e:  # Failed lookups result in a 403.
+        logging.warning(e)
+        return False

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,5 @@
 """The analysis-runner server, running Hail Batch pipelines on users' behalf."""
 
-import os
 import json
 import logging
 from aiohttp import web
@@ -12,24 +11,14 @@ from google.cloud import pubsub_v1
 import hailtop.batch as hb
 from hailtop.config import get_deploy_config
 
-GITHUB_ORG = 'populationgenomics'
+import cloud_identity
 
-ALLOWED_REPOS = {
-    'tob-wgs',
-}
+GITHUB_ORG = 'populationgenomics'
 
 DRIVER_IMAGE = (
     'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:ffc8144b0e1e'
 )
 
-# The GCP_PROJECT is the project ID, not the project name, and is therefore sometimes
-# not identical to the dataset name.
-GCP_PROJECT = os.getenv('GCP_PROJECT')
-assert GCP_PROJECT
-DATASET = os.getenv('DATASET')
-assert DATASET
-
-HAIL_BUCKET = f'cpg-{DATASET}-hail'
 METADATA_FILE = '/tmp/metadata.json'
 PUBSUB_TOPIC = 'projects/analysis-runner/topics/submissions'
 
@@ -59,7 +48,7 @@ def _shell_escape(arg: str) -> str:
 
 def _read_secret(name: str) -> str:
     """Reads the latest version of the given secret from Google's Secret Manager."""
-    secret_name = f'projects/{GCP_PROJECT}/secrets/{name}/versions/latest'
+    secret_name = f'projects/analysis-runner/secrets/{name}/versions/latest'
     response = secret_manager.access_secret_version(request={'name': secret_name})
     return response.payload.data.decode('UTF-8')
 
@@ -85,21 +74,42 @@ async def index(request):
                 reason='Output directory needs to start with "gs://"'
             )
 
+        dataset = params['dataset']
+        config = json.loads(_read_secret('server-config'))
+        if dataset not in config:
+            raise web.HTTPForbidden(
+                reason=(
+                    f'Dataset "{dataset}" is not part of: '
+                    f'{", ".join(config.keys())}'
+                )
+            )
+
+        extended_access = params['extendedAccess']
+        group_type = 'extended' if extended_access else 'restricted'
+        group_name = f'{dataset}-{group_type}-access@populationgenomics.org.au'
+        if not cloud_identity.check_group_membership(email, group_name):
+            raise web.HTTPForbidden(reason=f'{email} is not a member of {group_name}')
+
         repo = params['repo']
-        allowed_repos = _read_secret('allowed-repos').split(',')
+        allowed_repos = config[dataset]['allowedRepos']
         if repo not in allowed_repos:
             raise web.HTTPForbidden(
                 reason=(
-                    f'Repository "{repo}" is not in list of allowed repositories: '
+                    f'Repository "{repo}" is not one of the allowed repositories: '
                     f'{", ".join(allowed_repos)}'
                 )
             )
 
-        hail_token = _read_secret('hail-token')
+        hail_bucket = f'cpg-{dataset}-hail'
+        hail_token = (
+            config[dataset]['extendedToken']
+            if extended_access
+            else config[dataset]['token']
+        )
 
         backend = hb.ServiceBackend(
-            billing_project=DATASET,
-            bucket=HAIL_BUCKET,
+            billing_project=dataset,
+            bucket=hail_bucket,
             token=hail_token,
         )
 
@@ -124,8 +134,8 @@ async def index(request):
         job = batch.new_job(name='driver')
         job.image(DRIVER_IMAGE)
 
-        job.env('HAIL_BILLING_PROJECT', DATASET)
-        job.env('HAIL_BUCKET', HAIL_BUCKET)
+        job.env('HAIL_BILLING_PROJECT', dataset)
+        job.env('HAIL_BUCKET', hail_bucket)
         job.env('OUTPUT', output_dir)
 
         # Note: for private GitHub repos we'd need to use a token to clone.
@@ -147,8 +157,9 @@ async def index(request):
         # This metadata dictionary gets stored at the output_dir location.
         metadata = json.dumps(
             {
-                'dataset': DATASET,
+                'dataset': dataset,
                 'user': email,
+                'extendedAccess': extended_access,
                 'repo': repo,
                 'commit': commit,
                 'script': ' '.join(script),

--- a/stack/Pulumi.fewgenomes.yaml
+++ b/stack/Pulumi.fewgenomes.yaml
@@ -3,6 +3,7 @@ config:
   datasets:customer_id: C010ys3gt
   datasets:enable_release: "false"
   datasets:hail_service_account: fewgenomes-911@hail-295901.iam.gserviceaccount.com
+  datasets:hail_extended_service_account: fewgenomes-extended-778@hail-295901.iam.gserviceaccount.com
   gcp:billing_project: fewgenomes
   gcp:project: fewgenomes
   gcp:user_project_override: "true"

--- a/stack/Pulumi.tob-wgs.yaml
+++ b/stack/Pulumi.tob-wgs.yaml
@@ -4,6 +4,7 @@ config:
   datasets:customer_id: C010ys3gt
   datasets:enable_release: "false"
   datasets:hail_service_account: tob-wgs-960@hail-295901.iam.gserviceaccount.com
+  datasets:hail_extended_service_account: tob-wgs-extended-342@hail-295901.iam.gserviceaccount.com
   gcp:billing_project: tob-wgs
   gcp:project: tob-wgs
   gcp:user_project_override: "true"


### PR DESCRIPTION
It also simplifies the deployment by only running a single analysis-runner server instance.