### PR TITLE
Bump version: Run condarise action on merge with main

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.1.0
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:cli/_version.py]
 search = __version__ = '{current_version}'

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -1,9 +1,12 @@
 name: Condarise
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 jobs:
   build-publish:
     # Run on merge to master, where the commit name starts with "Bump version:" (for bump2version)
-    if: "startsWith(github.ref, 'refs/heads/main') && startsWith(github.event.head_commit.message, 'Bump version:')"
+    if: "startsWith(github.event.head_commit.message, 'Bump version:')"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build-publish:
     # Run for tags only
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/heads/main') && startsWith(github.event.head_commit.message, 'Bump version:')"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -2,7 +2,7 @@ name: Condarise
 on: [push, pull_request]
 jobs:
   build-publish:
-    # Run for tags only
+    # Run on merge to master, where the commit name starts with "Bump version:" (for bump2version)
     if: "startsWith(github.ref, 'refs/heads/main') && startsWith(github.event.head_commit.message, 'Bump version:')"
     runs-on: ubuntu-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ analysis-runner \
     script_to_run.py with arguments
 ```
 
-## Deployment
+## Development
 
 You can ignore this section if you just want to run the tool.
 
@@ -112,22 +112,22 @@ pip install --editable .
 1. Deploy the [Airtable](airtable) publisher.
 1. Publish the [CLI tool](cli) to conda.
 
+### Deploying CLI tool
+
 CLI tool is shipped as a conda package. To build a new version,
 we use [bump2version](https://pypi.org/project/bump2version/).
 For example, to increment the patch section of the version tag 1.0.0 and make
 it 1.0.1, run:
 
 ```bash
+git checkout -b bump-version-for-release
 bump2version patch
+git push --set-upstream origin add-new-version
+# Open pull request
+open "https://github.com/populationgenomics/analysis-runner/pull/new/add-new-version"
 ```
 
-It will update the version tag specified in `setup.py` and `*/_version.py`,
-and create a new git tag. You can push the tag with:
-
-```bash
-git push --tags
-```
-
-This will trigger the GitHub Actions workflow to build a new conda package, that
+It's important the pull request name start with "Bump version:" (which should happen by default).
+Once this is merged into `main`, a GitHub action workflow will build a new conda package, that
 will be uploaded to the Anaconda [CPG channel](https://anaconda.org/cpg/),
 and become available to install with `conda install -c cpg -c conda-forge ...`


### PR DESCRIPTION
Per discussion, run on:
- merge to master, AND
- where the commit name starts with: "Bump version:"

This is the result: `refs/heads/main Create test-wf.yaml` for the following action on a commit to main with commit message: "Create test-wf.yaml`.

```yaml
name: preparebuild
on: [push, pull_request]
jobs:
  build-publish:
    runs-on: ubuntu-latest
    steps:
      - run: |
          echo ${{ github.ref }} ${{ github.event.head_commit.message }}
``` 

I've named this PR: "Bump version: ..." to trigger the latest release from (#31).
