### PR TITLE
Clean up containers

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -11,3 +11,6 @@ ENV PATH /root/miniconda3/bin:$PATH
 
 # Install Hail from the conda CPG channel.
 RUN conda install -y -c cpg -c bioconda -c conda-forge hail=0.2.62.devcdb8c94
+
+# Clean up
+RUN rm -rf /root/miniconda3/pkgs

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,3 +12,6 @@ EXPOSE $PORT
 COPY main.py cloud_identity.py ./
 
 CMD gunicorn --bind :$PORT --worker-class aiohttp.GunicornWebWorker main:init_func
+
+# Clean up
+RUN rm -rf /root/miniconda3/pkgs


### PR DESCRIPTION
Clean up conda package source tarballs as the last step of the driver and server images build. Reduces the size of the drive image by 1.9G.