### PR TITLE
Container clean-up fix - account for layers

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -3,14 +3,15 @@
 FROM marketplace.gcr.io/google/ubuntu1804
 
 # Install git.
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git &&\
+    rm -r /var/lib/apt/lists/* &&\
+    rm -r /var/cache/apt/*
 
-# Install Miniconda.
-RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh && bash miniconda.sh -b && rm miniconda.sh
 ENV PATH /root/miniconda3/bin:$PATH
 
-# Install Hail from the conda CPG channel.
-RUN conda install -y -c cpg -c bioconda -c conda-forge hail=0.2.62.devcdb8c94
-
-# Clean up
-RUN rm -rf /root/miniconda3/pkgs
+# Install Miniconda & Hail from the conda CPG channel
+RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh &&\
+	bash miniconda.sh -b &&\
+	rm miniconda.sh &&\
+    conda install -y -c cpg -c bioconda -c conda-forge hail=0.2.62.devcdb8c94 &&\
+	rm -r /root/miniconda3/pkgs /root/miniconda3/src.zip

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH /root/miniconda3/bin:$PATH
 
 # Install Miniconda & Hail from the conda CPG channel
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh &&\
-	bash miniconda.sh -b &&\
-	rm miniconda.sh &&\
+    bash miniconda.sh -b &&\
+    rm miniconda.sh &&\
     conda install -y -c cpg -c bioconda -c conda-forge hail=0.2.62.devcdb8c94 &&\
-	rm -r /root/miniconda3/pkgs /root/miniconda3/src.zip
+    rm -r /root/miniconda3/pkgs /root/miniconda3/src.zip

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,13 @@
 # Since the server relies on Hail as well, we're reusing the driver image.
-FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:f2fc08ff8c5e'
+FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:50ac35f838ae'
 
-RUN conda install -c conda-forge google-api-python-client=1.12.8 google-auth==1.24.0 google-cloud-secret-manager==2.2.0 google-cloud-pubsub==2.3.0 gunicorn
+RUN conda install -c conda-forge\
+	google-api-python-client=1.12.8\
+	google-auth==1.24.0\
+	google-cloud-secret-manager==2.2.0\
+	google-cloud-pubsub==2.3.0\
+	gunicorn &&\
+	rm -r /root/miniconda3/pkgs
 
 # Allow statements and log messages to immediately appear in the Knative logs.
 ENV PYTHONUNBUFFERED 1
@@ -12,6 +18,3 @@ EXPOSE $PORT
 COPY main.py cloud_identity.py ./
 
 CMD gunicorn --bind :$PORT --worker-class aiohttp.GunicornWebWorker main:init_func
-
-# Clean up
-RUN rm -rf /root/miniconda3/pkgs

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,12 +2,12 @@
 FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:50ac35f838ae'
 
 RUN conda install -c conda-forge\
-	google-api-python-client=1.12.8\
-	google-auth==1.24.0\
-	google-cloud-secret-manager==2.2.0\
-	google-cloud-pubsub==2.3.0\
-	gunicorn &&\
-	rm -r /root/miniconda3/pkgs
+    google-api-python-client=1.12.8\
+    google-auth==1.24.0\
+    google-cloud-secret-manager==2.2.0\
+    google-cloud-pubsub==2.3.0\
+    gunicorn &&\
+    rm -r /root/miniconda3/pkgs
 
 # Allow statements and log messages to immediately appear in the Knative logs.
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
https://github.com/populationgenomics/analysis-runner/pull/33 hasn't ultimately reduced the size of the container, because the cleaning was happening in an extra layer.

```
australia-southeast1-docker.pkg.dev/analysis-runner/images/driver                    50ac35f838ae                                                       7add2620fa57   About an hour ago   1.75GB
australia-southeast1-docker.pkg.dev/analysis-runner/images/driver                    <none>                                                             f20045ff9d2b   17 hours ago        3.35GB
```

Moving cleaning the conda stuff into the same layer as the conda command.

Also cleaning the apt cache for some extra space.

In the future will be able to free 400M more by getting rid of Spark.