### PR TITLE
Add a workflow for continuous server deployment

### DIFF
--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -26,6 +26,10 @@ jobs:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
 
+    - name: "gcloud docker auth"
+      run: |
+        gcloud auth configure-docker gcr.io
+
     - name: "build driver image"
       run: |
         docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -49,4 +49,4 @@ jobs:
 
     - name: "deploy server"
       run: |
-        gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --image $SERVER_IMAGE
+        gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE --image $SERVER_IMAGE

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: "gcloud docker auth"
       run: |
-        gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+        gcloud auth configure-docker marketplace.gcr.io,australia-southeast1-docker.pkg.dev
 
     - name: "build driver image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: "build server image"
       run: |
-        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE server
+        docker build --build-arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE server
 
     - name: "push server image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -25,6 +25,7 @@ jobs:
       with:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+        export_default_credentials: true
 
     - name: "gcloud docker auth"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -23,7 +23,8 @@ jobs:
     - name: "build driver image"
       run: |
         pwd
-        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE analysis-runner/driver
+        ls
+        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver
 
     - name: "push driver image"
       run: |
@@ -31,7 +32,7 @@ jobs:
 
     - name: "build server image"
       run: |
-        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE analysis-runner/server
+        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE server
 
     - name: "push server image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -1,0 +1,42 @@
+# This workflow is triggered after a new version of Hail has been built, with a
+# corresponding conda package. It leads to new driver and server Docker images being
+# built, followed by the deployment of the server.
+on:
+  workflow_dispatch:
+    inputs:
+      hail_version:
+        description: 'Hail version (as uploaded to Anaconda)'
+        required: true
+
+jobs:
+  deploy_server:
+    runs-on: ubuntu-latest
+
+    env:
+      DRIVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
+      SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
+
+    steps:
+    - name: "build driver image"
+      run: |
+        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE
+
+    - name: "push driver image"
+      run: |
+        docker push $DRIVER_IMAGE
+
+    - name: "build server image"
+      run: |
+        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE
+
+    - name: "push server image"
+      run: |
+        docker push $SERVER_IMAGE
+
+    - name: "deploy server"
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        project_id: analysis-runner
+        service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+      run: |
+        gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --image $SERVER_IMAGE

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -17,9 +17,12 @@ jobs:
       SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
 
     steps:
+    - name: "checkout repo"
+      uses: actions/checkout@v2
+
     - name: "build driver image"
       run: |
-        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver
+        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE analysis-runner/driver
 
     - name: "push driver image"
       run: |
@@ -27,7 +30,7 @@ jobs:
 
     - name: "build server image"
       run: |
-        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE server
+        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE analysis-runner/server
 
     - name: "push server image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: "gcloud docker auth"
       run: |
-        gcloud auth configure-docker gcr.io australia-southeast1-docker.pkg.dev
+        gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
     - name: "build driver image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
       DRIVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
       SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
 
@@ -25,7 +27,6 @@ jobs:
       with:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
-        export_default_credentials: true
 
     - name: "gcloud docker auth"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -33,10 +33,12 @@ jobs:
       run: |
         docker push $SERVER_IMAGE
 
-    - name: "deploy server"
+    - name: "gcloud setup"
       uses: google-github-actions/setup-gcloud@master
       with:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+
+    - name: "deploy server"
       run: |
         gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --image $SERVER_IMAGE

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -20,10 +20,14 @@ jobs:
     - name: "checkout repo"
       uses: actions/checkout@v2
 
+    - name: "gcloud setup"
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        project_id: analysis-runner
+        service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
+
     - name: "build driver image"
       run: |
-        pwd
-        ls
         docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver
 
     - name: "push driver image"
@@ -37,12 +41,6 @@ jobs:
     - name: "push server image"
       run: |
         docker push $SERVER_IMAGE
-
-    - name: "gcloud setup"
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: analysis-runner
-        service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
 
     - name: "deploy server"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - name: "gcloud docker auth"
       run: |
-        gcloud auth configure-docker gcr.io
+        gcloud auth configure-docker gcr.io australia-southeast1-docker.pkg.dev
 
     - name: "build driver image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -22,6 +22,7 @@ jobs:
 
     - name: "build driver image"
       run: |
+        pwd
         docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE analysis-runner/driver
 
     - name: "push driver image"

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: "build driver image"
       run: |
-        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE
+        docker build --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver
 
     - name: "push driver image"
       run: |
@@ -27,7 +27,7 @@ jobs:
 
     - name: "build server image"
       run: |
-        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE
+        docker build --build_arg DRIVER_IMAGE=$DRIVER_IMAGE --tag $SERVER_IMAGE server
 
     - name: "push server image"
       run: |

--- a/.github/workflows/hail_update.yaml
+++ b/.github/workflows/hail_update.yaml
@@ -15,6 +15,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
       DRIVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
       SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,23 @@ pre-commit install
 pip install --editable .
 ```
 
+### Deployment
+
 1. Add a Hail Batch service account for all supported datasets.
 1. [Copy the Hail tokens](tokens) to the Secret Manager.
-1. Build the [driver image](driver).
-1. Deploy the [server](server) for each dataset.
+1. Deploy the [server](server) by invoking the [`hail_update` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/hail_update.yaml) manually, specifying the Hail package version in conda.
 1. Deploy the [Airtable](airtable) publisher.
 1. Publish the [CLI tool](cli) to conda.
 
-### Deploying CLI tool
+Note that the [`hail_update` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/hail_update.yaml) gets invoked whenever a new Hail package is published to conda. You can test this manually as follows:
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/populationgenomics/analysis-runner/actions/workflows/6364059/dispatches \
+  -d '{"ref": "main", "inputs": {"hail_version": "0.2.63.deveb7251e548b1"}}'
+```
 
 CLI tool is shipped as a conda package. To build a new version,
 we use [bump2version](https://pypi.org/project/bump2version/).
@@ -129,5 +138,5 @@ open "https://github.com/populationgenomics/analysis-runner/pull/new/add-new-ver
 
 It's important the pull request name start with "Bump version:" (which should happen by default).
 Once this is merged into `main`, a GitHub action workflow will build a new conda package, that
-will be uploaded to the Anaconda [CPG channel](https://anaconda.org/cpg/),
+will be uploaded to the conda [CPG channel](https://anaconda.org/cpg/),
 and become available to install with `conda install -c cpg -c conda-forge ...`

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -1,3 +1,5 @@
+ARG HAIL_VERSION
+
 # Cloud Run doesn't like Ubuntu 20.04:
 # https://stackoverflow.com/questions/61744540/unable-to-deploy-ubuntu-20-04-docker-container-on-google-cloud-run
 FROM marketplace.gcr.io/google/ubuntu1804
@@ -13,5 +15,5 @@ ENV PATH /root/miniconda3/bin:$PATH
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh &&\
     bash miniconda.sh -b &&\
     rm miniconda.sh &&\
-    conda install -y -c cpg -c bioconda -c conda-forge hail=0.2.62.devcdb8c94 &&\
+    conda install -y -c cpg -c bioconda -c conda-forge hail=${HAIL_VERSION} &&\
     rm -r /root/miniconda3/pkgs /root/miniconda3/src.zip

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -1,8 +1,8 @@
-ARG HAIL_VERSION
-
 # Cloud Run doesn't like Ubuntu 20.04:
 # https://stackoverflow.com/questions/61744540/unable-to-deploy-ubuntu-20-04-docker-container-on-google-cloud-run
 FROM marketplace.gcr.io/google/ubuntu1804
+
+ARG HAIL_VERSION
 
 # Install git.
 RUN apt-get update && apt-get install -y git &&\
@@ -15,5 +15,5 @@ ENV PATH /root/miniconda3/bin:$PATH
 RUN curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh &&\
     bash miniconda.sh -b &&\
     rm miniconda.sh &&\
-    conda install -y -c cpg -c bioconda -c conda-forge hail=${HAIL_VERSION} &&\
+    conda install -y -c cpg -c bioconda -c conda-forge hail=$HAIL_VERSION &&\
     rm -r /root/miniconda3/pkgs /root/miniconda3/src.zip

--- a/driver/README.md
+++ b/driver/README.md
@@ -18,6 +18,3 @@ IMAGE=australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
 COMMIT_HASH=$(git rev-parse --short=12 HEAD)
 gcloud builds submit --timeout 1h --tag $IMAGE:$COMMIT_HASH
 ```
-
-Update the corresponding version reference in the [server](../server) and
-redeploy.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,6 @@
 # Since the server relies on Hail as well, we're reusing the driver image.
-FROM 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:50ac35f838ae'
+ARG DRIVER_IMAGE
+FROM ${DRIVER_IMAGE}
 
 RUN conda install -c conda-forge\
     google-api-python-client=1.12.8\

--- a/server/README.md
+++ b/server/README.md
@@ -21,12 +21,12 @@ echo $COMMIT_HASH
 gcloud builds submit --timeout 1h --tag $IMAGE:$COMMIT_HASH
 ```
 
-To deploy, run:
+Deployment happens continuously using the [`hail_update` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/hail_update.yaml). However, if you ever need to deploy manually, run:
 
 ```bash
 gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated \
     --service-account analysis-runner-server@analysis-runner.iam.gserviceaccount.com \
-    --platform managed --image $IMAGE:$COMMIT_HASH
+    --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE --image $IMAGE:$COMMIT_HASH
 ```
 
 Hail service account [tokens](../tokens) need to be copied to a Secret Manager secret
@@ -44,7 +44,7 @@ Download a JSON key for the `analysis-runner-server` service account. Store the 
 ```bash
 docker build -t analysis-runner-server .
 
-docker run -it -p 8080:8080 -v $GSA_KEY_FILE:/gsa-key/key.json -e GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json analysis-runner-server
+docker run -it -p 8080:8080 -v $GSA_KEY_FILE:/gsa-key/key.json -e GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json -e DRIVER_IMAGE=$DRIVER_IMAGE analysis-runner-server
 ```
 
 This will start a server that listens locally on port 8080.

--- a/server/main.py
+++ b/server/main.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from aiohttp import web, ClientSession
 
 from google.auth import jwt
@@ -14,13 +15,11 @@ from hailtop.config import get_deploy_config
 import cloud_identity
 
 GITHUB_ORG = 'populationgenomics'
-
-DRIVER_IMAGE = (
-    'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:0280c2d75fae'
-)
-
 METADATA_FILE = '/tmp/metadata.json'
 PUBSUB_TOPIC = 'projects/analysis-runner/topics/submissions'
+
+DRIVER_IMAGE = os.getenv('DRIVER_IMAGE')
+assert DRIVER_IMAGE
 
 routes = web.RouteTableDef()
 


### PR DESCRIPTION
See #37 for context.

This workflow should be triggered whenever a new Hail package gets released to conda (see https://github.com/populationgenomics/hail/pull/72).

It builds a new driver image, server image, and deploys to Cloud Run.

Example run: https://github.com/populationgenomics/analysis-runner/runs/2028560588