### PR TITLE
Enable uniform bucket permissions

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -37,6 +37,7 @@ def create_bucket(name: str, **kwargs) -> gcp.storage.Bucket:
         name,
         name=name,
         location=REGION,
+        uniform_bucket_level_access=True,
         versioning=gcp.storage.BucketVersioningArgs(enabled=True),
         labels={'bucket': name},
         **kwargs,


### PR DESCRIPTION
This is the recommended setting: https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use