### PR TITLE
Add git stash to clean working directory before build

### DIFF
--- a/driver/README.md
+++ b/driver/README.md
@@ -14,7 +14,9 @@ Then run:
 ```bash
 gcloud config set project analysis-runner
 
+git stash
 IMAGE=australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
 COMMIT_HASH=$(git rev-parse --short=12 HEAD)
 gcloud builds submit --timeout 1h --tag $IMAGE:$COMMIT_HASH
+git stash pop
 ```

--- a/driver/README.md
+++ b/driver/README.md
@@ -8,15 +8,6 @@ defines the Hail Batch pipeline.
 Therefore, the main dependency that's installed is Hail, which comes with the
 Batch API bindings.
 
-To build this image, make sure that you don't have any uncommitted changes.
-Then run:
+The driver image gets rebuilt and pushed automatically as part of the [Hail update workflow](../.github/workflows/hail_update.yaml).
 
-```bash
-gcloud config set project analysis-runner
 
-git stash
-IMAGE=australia-southeast1-docker.pkg.dev/analysis-runner/images/driver
-COMMIT_HASH=$(git rev-parse --short=12 HEAD)
-gcloud builds submit --timeout 1h --tag $IMAGE:$COMMIT_HASH
-git stash pop
-```

--- a/driver/README.md
+++ b/driver/README.md
@@ -9,5 +9,3 @@ Therefore, the main dependency that's installed is Hail, which comes with the
 Batch API bindings.
 
 The driver image gets rebuilt and pushed automatically as part of the [Hail update workflow](../.github/workflows/hail_update.yaml).
-
-


### PR DESCRIPTION
Instructions mention to have a clean working directory, but just a small suggestion to add `git stash` to the instructions to stash the changes in the potentially dirty working directory away, then pop them back later.

Just an idea, happy to close this if it's not valuable :)