### PR TITLE
Convert click to argparse for flexibility

### DIFF
--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -134,7 +134,8 @@ def _get_google_auth_token() -> str:
 
 def parse_args(args=None):
     """
-    Parse args using argparse (if args is None, argparse automatically uses `sys.argv`) 
+    Parse args using argparse
+    (if args is None, argparse automatically uses `sys.argv`)
     """
     parser = argparse.ArgumentParser()
     # https://docs.python.org/dev/library/argparse.html#action

--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -29,7 +29,7 @@ SERVER_ENDPOINT = 'https://server-a2pko7ameq-ts.a.run.app'
 
 def main_from_args(args=None):
     """
-    Parse arguments (if args is None, argparse automatically uses `sys.argv`) and run main
+    Parse args (if args is None, argparse automatically uses sys.argv) and run main
     """
     args = parse_args(args=args)
     return main(**vars(args))

--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -29,7 +29,7 @@ SERVER_ENDPOINT = 'https://server-a2pko7ameq-ts.a.run.app'
 
 def main_from_args(args=None):
     """
-    Parse arguments (default: sys.argv) and run main
+    Parse arguments (if args is None, argparse automatically uses `sys.argv`) and run main
     """
     args = parse_args(args=args)
     return main(**vars(args))
@@ -134,7 +134,7 @@ def _get_google_auth_token() -> str:
 
 def parse_args(args=None):
     """
-    Parse args using argparse (
+    Parse args using argparse (if args is None, argparse automatically uses `sys.argv`) 
     """
     parser = argparse.ArgumentParser()
     # https://docs.python.org/dev/library/argparse.html#action


### PR DESCRIPTION
I couldn't make `@click` do what we wanted, eg: parsing only a subset of `sys.argv`, but script isn't a named parameter, it's just the remainder of args. So I've reverted this back to argparse (and implemented a cheap "confirm" function).