### PR TITLE
Add other execution types

### DIFF
--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -43,6 +43,7 @@ def main(
     access_level,
     commit=None,
     repository=None,
+    execution_type=None,
 ):
     """
     Main function that drives the CLI.
@@ -70,6 +71,10 @@ def main(
     if not _script:
         _script = ['main.py']
 
+    # potentially TODO: determine execution_type from file extension
+    #   if the execution_type is None (then set default in click to None)
+    # execution_type = get_execution_type_from_script(_script)
+
     if repository is None:
         _repository = get_repo_name_from_remote(get_git_default_remote())
         if _commit_ref is None:
@@ -93,6 +98,7 @@ def main(
             'commit': _commit_ref,
             'script': _script,
             'description': description,
+            'execution_type': execution_type,
         },
         headers={'Authorization': f'Bearer {_token}'},
     )
@@ -185,6 +191,13 @@ def parse_args(args=None):
         choices=(['test', 'standard', 'full']),
         default='test',
         help='Which permissions to grant when running the job.',
+    )
+
+    parser.add_argument(
+        '--execution-type',
+        choices=(['python', 'r', 'bash', 'custom']),
+        default='python',
+        help='Determine which executor is used to run the script',
     )
 
     parser.add_argument('script', nargs=argparse.REMAINDER, default=[])

--- a/server/main.py
+++ b/server/main.py
@@ -57,8 +57,13 @@ class ExecutionType(Enum):
 
         return images.get(self, DRIVER_IMAGE)
 
-    def prepare_commands(self, script, arguments) -> List[str]:
-        """Return list of commands required to run {script} with {arguments}"""
+    def prepare_commands(self, script, arguments, **kwargs) -> List[str]:
+        """
+        Return list of commands required to run {script} with {arguments}
+        Kwargs might be a list of elements that a specific subtype of
+            'prepare_*_command' is looking for, eg: R might look for
+            'r_packages' as a kwarg (to prepare install commands).
+        """
         script_builders = {
             self.PYTHON3: self.prepare_python3_command,
             self.R: self.prepare_r_command,
@@ -66,29 +71,29 @@ class ExecutionType(Enum):
             self.CUSTOM: self.prepare_custom_command,
         }
 
-        return_commands = script_builders[self](script, arguments)
+        return_commands = script_builders[self](script, arguments, **kwargs)
         if not isinstance(return_commands, list):
             return_commands = [return_commands]
         return return_commands
 
     @staticmethod
-    def prepare_python3_command(command, arguments):
+    def prepare_python3_command(command, arguments, **_):
         """Prepare run command for python3"""
         return f'python3 {command} {arguments}'
 
     @staticmethod
-    def prepare_r_command(command, arguments):
+    def prepare_r_command(command, arguments, **_):
         """Prepare run command for Rscript"""
         # R vs Rscript: https://stackoverflow.com/a/22355386
         return f'Rscript {command} {arguments}'
 
     @staticmethod
-    def prepare_bash_command(command, arguments):
+    def prepare_bash_command(command, arguments, **_):
         """Prepare run command for bash"""
         return f'bash {command} {arguments}'
 
     @staticmethod
-    def prepare_custom_command(command, arguments):
+    def prepare_custom_command(command, arguments, **_):
         """
         Prepare run commands for an arbitrary script,
             1. assume the script has a #! SHEBANG


### PR DESCRIPTION
Added R, Bash and Custom execution types by introducing `ExecutionType` enum. 
Still have to resolve which images will be used for the R and Custom types. Each image would have to contain at least `gcloud`. Currently it just resolves to the `DRIVER_IMAGE`.

 > We might consider users providing their own container, but it also means they can run arbitrary code without code review on production data. Maybe "test" could run any image, and standard must use an image from a specific artefact registry?

Any thoughts on this first draft implementation?