### PR TITLE
Genericise analysis runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,3 @@ It's important the pull request name start with "Bump version:" (which should ha
 by default). Once this is merged into `main`, a GitHub action workflow will build a
 new conda package that will be uploaded to the conda [CPG
 channel](https://anaconda.org/cpg/), and become available to install with `mamba install -c cpg -c conda-forge ...`
-
-## Limitations
-
-- Your script name cannot contain spaces, even if you quote it.

--- a/README.md
+++ b/README.md
@@ -123,3 +123,7 @@ It's important the pull request name start with "Bump version:" (which should ha
 by default). Once this is merged into `main`, a GitHub action workflow will build a
 new conda package that will be uploaded to the conda [CPG
 channel](https://anaconda.org/cpg/), and become available to install with `mamba install -c cpg -c conda-forge ...`
+
+## Limitations
+
+- Your script name cannot contain spaces, even if you quote it.

--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -161,7 +161,7 @@ def _perform_shebang_check(script):
     with open(script) as f:
         potential_shebang = f.readline()
         if potential_shebang.startswith('#!'):
-            return True
+            return
 
         suggestion_shebang = ''
         if script.endswith('.py'):
@@ -171,10 +171,10 @@ def _perform_shebang_check(script):
         elif script.lower().endswith('.r') or script.lower().endswith('.rscript'):
             suggestion_shebang = '#!/usr/bin/env Rscript'
 
-        message = f"Couldn't find shebang at start of '{script}'"
+        message = f'Couldn't find shebang at start of "{script}"'
         if suggestion_shebang:
             message += (
-                f", consider inserting '{suggestion_shebang}' at the top of this file"
+                f', consider inserting "{suggestion_shebang}" at the top of this file'
             )
         raise Exception(message)
 

--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -79,6 +79,11 @@ def main(
     if _script[0]:
         if os.path.exists(_script[0]):
             _perform_shebang_check(_script[0])
+            # if it's just the path name, eg: you call
+            #   analysis-runner myfile.py
+            # need to pre-pend "./" to execute
+            if os.path.basename(_script[0]) == _script[0]:
+                _script[0] = './' + _script[0]
         elif not which(_script[0]):
             # the first el of _script is not executable
             # (at least on this computer)

--- a/analysis_runner/cli.py
+++ b/analysis_runner/cli.py
@@ -69,13 +69,6 @@ def main(
     _script = list(script)
     _cwd = None
 
-    if ' ' in _script[0]:
-        # Some analysts will quote the whole script, eg:
-        #   analysis-runner 'myscript.py --flag --param arg'
-        # so we'll normalise this by splitting the first element.
-        # This means that your script names can't have spaces in them.
-        _script = _script[0].split() + _script[1:]
-
     # false-y value catches empty list / tuple as well
     if not _script:
         _script = ['main.py']

--- a/analysis_runner/git.py
+++ b/analysis_runner/git.py
@@ -35,9 +35,14 @@ def get_relative_script_path_from_git_root(script_name: str) -> str:
 
         analysis_runner/git.py
     """
+    base = get_relative_path_from_git_root()
+    return os.path.join(base, script_name)
+
+
+def get_relative_path_from_git_root() -> str:
     root = get_git_repo_root()
     base = os.path.relpath(os.getcwd(), root)
-    return os.path.join(base, script_name)
+    return base
 
 
 def get_git_default_remote() -> str:

--- a/analysis_runner/git.py
+++ b/analysis_runner/git.py
@@ -30,8 +30,8 @@ def get_output_of_command(command: List[str], description: str) -> str:
 def get_relative_script_path_from_git_root(script_name: str) -> str:
     """
     If we're in a subdirectory, get the relative path from the git root
-    to the current directory. For example, the relative path to this
-    script directly is:
+    to the current directory, and append the script path.
+    For example, the relative path to this script (from git root) is:
 
         analysis_runner/git.py
     """
@@ -40,6 +40,10 @@ def get_relative_script_path_from_git_root(script_name: str) -> str:
 
 
 def get_relative_path_from_git_root() -> str:
+    """
+    If we're in a subdirectory, get the relative path from the git root
+    to the current directory. Relpath returns "." if cwd is a git root.
+    """
     root = get_git_repo_root()
     base = os.path.relpath(os.getcwd(), root)
     return base

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:buster-slim
+# uses debian base
+FROM rocker/tidyverse:4.0.4
 
 ARG HAIL_VERSION
 

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -1,5 +1,4 @@
-# uses debian base
-FROM rocker/tidyverse:4.0.4
+FROM debian:buster-slim
 
 ARG HAIL_VERSION
 
@@ -12,7 +11,10 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     rm -r /var/cache/apt/* && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
-    micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c cpg -c bioconda -c conda-forge hail=$HAIL_VERSION analysis-runner bokeh selenium phantomjs && \
+    micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
+        -c cpg -c bioconda -c conda-forge \
+        hail=$HAIL_VERSION analysis-runner bokeh selenium phantomjs \
+        r-base=4.0.3 r-essentials r-tidyverse && \
     rm -r /root/micromamba/pkgs && \
     # hailctl dataproc uses gcloud beta dataproc.
     gcloud -q components install beta

--- a/server/main.py
+++ b/server/main.py
@@ -220,11 +220,11 @@ async def index(request):
 
         # if
         job.command(
-            f'''\
+            f"""\
 if [[ -f {quote(script[0])} ]] then
     chmod +x {quote(script[0])}
 fi
-'''
+"""
         )
 
         # Finally, run the script.

--- a/server/main.py
+++ b/server/main.py
@@ -130,15 +130,14 @@ async def index(request):
         if not commit or commit == 'HEAD':
             raise web.HTTPBadRequest(reason='Invalid commit parameter')
 
-        cwd = params.get('cwd')
+        # make cwd non-optional to make all old clients break
+        cwd = params['cwd']
         script = params['script']
         if not script:
             raise web.HTTPBadRequest(reason='Invalid script parameter')
 
         if not isinstance(script, list):
             raise web.HTTPBadRequest(reason='Script parameter expects an array')
-
-        # script_file, *script_args = script
 
         user_name = email.split('@')[0]
         batch_name = f'{user_name} {repo}:{commit}/{" ".join(script)}'
@@ -218,7 +217,6 @@ async def index(request):
             f'gsutil cp {METADATA_PREFIX}.json {quote(output_dir)}/metadata.json'
         )
 
-        # if
         job.command(
             f"""\
 if [[ -f {quote(script[0])} ]] then

--- a/server/main.py
+++ b/server/main.py
@@ -130,7 +130,6 @@ async def index(request):
         if not commit or commit == 'HEAD':
             raise web.HTTPBadRequest(reason='Invalid commit parameter')
 
-        # make cwd non-optional to make all old clients break
         cwd = params['cwd']
         script = params['script']
         if not script:

--- a/server/main.py
+++ b/server/main.py
@@ -216,14 +216,7 @@ async def index(request):
         job.command(
             f'gsutil cp {METADATA_PREFIX}.json {quote(output_dir)}/metadata.json'
         )
-        if not script[0].startswith('/'):
-            job.command(
-                f"""\
-if [[ -f {quote(script[0])} ]] then
-    chmod +x {quote(script[0])}
-fi
-    """
-            )
+        job.command(f'which {quote(script[0])} || chmod +x {quote(script[0])}')
 
         # Finally, run the script.
         escaped_script = ' '.join(quote(s) for s in script if s)

--- a/server/main.py
+++ b/server/main.py
@@ -216,14 +216,14 @@ async def index(request):
         job.command(
             f'gsutil cp {METADATA_PREFIX}.json {quote(output_dir)}/metadata.json'
         )
-
-        job.command(
-            f"""\
+        if not script[0].startswith('/'):
+            job.command(
+                f"""\
 if [[ -f {quote(script[0])} ]] then
     chmod +x {quote(script[0])}
 fi
-"""
-        )
+    """
+            )
 
         # Finally, run the script.
         escaped_script = ' '.join(quote(s) for s in script if s)


### PR DESCRIPTION
On review of https://github.com/populationgenomics/analysis-runner/pull/80, performing the following:

Server:
- still remove `python3`
- remove the inferred working directory (prev `$(basename script[0])`), in favour of an explicit `cwd`
  - This is also passed to the airtable meta
- If `script[0]` exists, (`-f`), make it executable with `chmod +x {script[0]}`

CLI:
- Determine cwd from git root
- If the `script[0]` is a file, and exists:
  - perform a check for shebang
- or see if the first element (`script[0]`) is executable (through `shutil.which`), and makes you CONFIRM if it isn't.
  - This check doesn't guarantee anything (because the container the job runs in might include some executable that your host computer doesn't), but it's safety net for misspelled scripts.