### PR TITLE
Add zip to dataproc image

### DIFF
--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -2,4 +2,6 @@ FROM google/cloud-sdk:335.0.0
 
 ARG HAIL_VERSION=0.2.64
 
+RUN apt-get update && apt-get install -y zip
+
 RUN pip3 install hail==$HAIL_VERSION


### PR DESCRIPTION
Required to compress pyfiles to submit to the cluster: https://github.com/populationgenomics/analysis-runner/blob/main/analysis_runner/dataproc.py#L89