### PR TITLE
Update Hail from 0.2.64 to 0.2.65

### DIFF
--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -11,7 +11,7 @@ from analysis_runner.git import (
 )
 
 DATAPROC_IMAGE = (
-    'australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc:hail-0.2.64'
+    'australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc:hail-0.2.65'
 )
 GCLOUD_AUTH = 'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
 GCLOUD_PROJECT = 'gcloud config set project hail-295901'

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:335.0.0
 
-ARG HAIL_VERSION=0.2.64
+ARG HAIL_VERSION=0.2.65
 
 RUN apt-get update && apt-get install -y zip
 

--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -6,5 +6,5 @@ This Docker image is used to launch Dataproc clusters when using the
 To build, run:
 
 ```sh
-gcloud builds submit --tag australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc:hail-0.2.64 .
+gcloud builds submit --tag australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc:hail-0.2.65 .
 ```


### PR DESCRIPTION
@KatalinaBobowik This should fix the following `gcsfs` version error:
```TypeError: __init__() got an unexpected keyword argument 'callback_timeout'```
(Also see https://github.com/dask/gcsfs/issues/372.)