### PR TITLE
Pulumi: add AR permissions to cpg-common

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -7,6 +7,7 @@ DOMAIN = 'populationgenomics.org.au'
 CUSTOMER_ID = 'C010ys3gt'
 REGION = 'australia-southeast1'
 ANALYSIS_RUNNER_PROJECT = 'analysis-runner'
+CPG_COMMON_PROJECT = 'cpg-common'
 ANALYSIS_RUNNER_SERVICE_ACCOUNT = (
     'analysis-runner-server@analysis-runner.iam.gserviceaccount.com'
 )
@@ -236,32 +237,23 @@ gcp.cloudidentity.GroupMembership(
 # Allow the Hail service accounts to pull images. Note that the global project will
 # refer to the dataset, but the Docker image is stored in the "analysis-runner"
 # project's Artifact Registry repository.
-gcp.artifactregistry.RepositoryIamMember(
-    'hail-service-account-test-images-reader',
-    project=ANALYSIS_RUNNER_PROJECT,
-    location=REGION,
-    repository='images',
-    role='roles/artifactregistry.reader',
-    member=f'serviceAccount:{hail_service_account_test}',
-)
-
-gcp.artifactregistry.RepositoryIamMember(
-    'hail-service-account-standard-images-reader',
-    project=ANALYSIS_RUNNER_PROJECT,
-    location=REGION,
-    repository='images',
-    role='roles/artifactregistry.reader',
-    member=f'serviceAccount:{hail_service_account_standard}',
-)
-
-gcp.artifactregistry.RepositoryIamMember(
-    'hail-service-account-full-images-reader',
-    project=ANALYSIS_RUNNER_PROJECT,
-    location=REGION,
-    repository='images',
-    role='roles/artifactregistry.reader',
-    member=f'serviceAccount:{hail_service_account_full}',
-)
+for access_level, service_account in zip(
+    ['test', 'standard', 'full'],
+    [
+        hail_service_account_test,
+        hail_service_account_standard,
+        hail_service_account_full,
+    ],
+):
+    for project in [ANALYSIS_RUNNER_PROJECT, CPG_COMMON_PROJECT]:
+        gcp.artifactregistry.RepositoryIamMember(
+            f'hail-service-account-{access_level}-images-reader-in-{project}',
+            project=project,
+            location=REGION,
+            repository='images',
+            role='roles/artifactregistry.reader',
+            member=f'serviceAccount:{service_account}',
+        )
 
 # The bucket used for Hail Batch pipelines.
 hail_bucket = create_bucket(bucket_name('hail'), lifecycle_rules=[undelete_rule])

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -235,8 +235,8 @@ gcp.cloudidentity.GroupMembership(
 )
 
 # Allow the Hail service accounts to pull images. Note that the global project will
-# refer to the dataset, but the Docker image is stored in the "analysis-runner"
-# project's Artifact Registry repository.
+# refer to the dataset, but the Docker images are stored in the "analysis-runner"
+# and "cpg-common" projects' Artifact Registry repositories.
 for access_level, service_account in [
     ('test', hail_service_account_test),
     ('standard', hail_service_account_standard),

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -237,14 +237,11 @@ gcp.cloudidentity.GroupMembership(
 # Allow the Hail service accounts to pull images. Note that the global project will
 # refer to the dataset, but the Docker image is stored in the "analysis-runner"
 # project's Artifact Registry repository.
-for access_level, service_account in zip(
-    ['test', 'standard', 'full'],
-    [
-        hail_service_account_test,
-        hail_service_account_standard,
-        hail_service_account_full,
-    ],
-):
+for access_level, service_account in [
+    ('test', hail_service_account_test),
+    ('standard', hail_service_account_standard),
+    ('full', hail_service_account_full),
+]:
     for project in [ANALYSIS_RUNNER_PROJECT, CPG_COMMON_PROJECT]:
         gcp.artifactregistry.RepositoryIamMember(
             f'hail-service-account-{access_level}-images-reader-in-{project}',


### PR DESCRIPTION
I move the images used in the joint calling pipeline to the `cpg-common` AR registry: https://console.cloud.google.com/artifacts/docker/cpg-common/australia-southeast1/joint-calling?project=cpg-common

So adding permissions for the accounts to read from that registry.

I also refactored the code a bit to avoid 6 repetitive blocks, let me know if you'd like that reverted :)

Also, the names of 3 existing RepositoryIamMember resources changed to make sure the project name is reflected:

Was:
```
hail-service-account-test-images-reader
hail-service-account-standard-images-reader
hail-service-account-full-images-reader
```

Now:

```
hail-service-account-test-images-reader-in-analysis-runner
hail-service-account-standard-images-reader-in-analysis-runner
hail-service-account-full-images-reader-in-analysis-runner
hail-service-account-test-images-reader-in-cpg-common
hail-service-account-standard-images-reader-in-cpg-common
hail-service-account-full-images-reader-in-cpg-common
```

Not sure if it's desirable?

Alternatively might also put all the images to the `analysis-runner` project instead.