### PR TITLE
Set driver image environment variable for launched job

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -139,6 +139,7 @@ async def index(request):
         job.env('HAIL_BILLING_PROJECT', dataset)
         job.env('HAIL_BUCKET', hail_bucket)
         job.env('OUTPUT', output_dir)
+        job.env('DRIVER_IMAGE', DRIVER_IMAGE)
 
         # Note: for private GitHub repos we'd need to use a token to clone.
         # Any job commands here are evaluated in a bash shell, so user arguments should


### PR DESCRIPTION
This makes it easier to reuse the same environment for sub-batches.