### PR TITLE
Restore google-auth dependency

### DIFF
--- a/conda/analysis-runner/meta.yaml
+++ b/conda/analysis-runner/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   host:
     - python
   run:
+    - google-auth ==1.24.0
     - click ==7.1.2
     - requests
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,6 +9,7 @@ dependencies:
   - flake8
   - flake8-bugbear
   - flask
+  - google-auth=1.24.0
   - google-cloud-secret-manager=2.2.0
   - google-cloud-pubsub=2.3.0
   - google-cloud-storage=1.38.0


### PR DESCRIPTION
This got lost in #99, but is still required for the cli
(see e.g. https://github.com/populationgenomics/analysis-runner/runs/2616991217?check_suite_focus=true).