### PR TITLE
Set `analysis` bucket to listing-only for humans

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -202,7 +202,7 @@ add_bucket_permissions(
     'access-group-analysis-bucket-viewer',
     access_group,
     analysis_bucket,
-    'roles/storage.objectViewer',
+    listing_role.name,
 )
 
 add_bucket_permissions(

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -199,7 +199,7 @@ add_bucket_permissions(
 )
 
 add_bucket_permissions(
-    'access-group-analysis-bucket-viewer',
+    'access-group-analysis-bucket-lister',
     access_group,
     analysis_bucket,
     listing_role.name,


### PR DESCRIPTION
We now have a `web` bucket and notebook support for the `test` bucket.