### PR TITLE
Add link to web bucket description in the policies.

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -2,4 +2,6 @@
 
 This is a simple proxy that serves static content from the access-restricted per-dataset [`web` buckets](https://github.com/populationgenomics/team-docs/tree/main/storage_policies#web-gscpg-stack-web).
 
+See the [storage policies](https://github.com/populationgenomics/team-docs/tree/main/storage_policies#web-gscpg-dataset-web) for more details.
+
 It's deployed manually, by triggering the corresponding [workflow](../.github/workflows/deploy_web_server.yaml).


### PR DESCRIPTION
Depends on https://github.com/populationgenomics/team-docs/pull/94.