### PR TITLE
Add md5sum wdl example

### DIFF
--- a/examples/cromwell/hello.wdl
+++ b/examples/cromwell/hello.wdl
@@ -1,25 +1,16 @@
 version development
 
 import "tools/echo.wdl" as E
-import "tools/md5sum.wdl" as M
 
 workflow hello {
   input {
     String? inp = "Hello, world!"
-    File inpf
-    String prefix
   }
   call E.echo as print {
     input:
       inp = select_first([inp, "Hello, world!"])
   }
-  call M.md5sum as md5 {
-    input:
-      in_file = inpf,
-      prefix = prefix
-  }
   output {
     String out = print.out
-    File md5_res = md5.out_file
   }
 }

--- a/examples/cromwell/hello.wdl
+++ b/examples/cromwell/hello.wdl
@@ -1,16 +1,25 @@
 version development
 
 import "tools/echo.wdl" as E
+import "tools/md5sum.wdl" as M
 
 workflow hello {
   input {
     String? inp = "Hello, world!"
+    File inpf
+    String prefix
   }
   call E.echo as print {
     input:
       inp = select_first([inp, "Hello, world!"])
   }
+  call M.md5sum as md5 {
+    input:
+      in_file = inpf,
+      prefix = prefix
+  }
   output {
     String out = print.out
+    File md5_res = md5.out_file
   }
 }

--- a/examples/cromwell/md5sum_wf.wdl
+++ b/examples/cromwell/md5sum_wf.wdl
@@ -1,0 +1,18 @@
+version development
+
+import "tools/md5sum.wdl" as M
+
+workflow md5sum {
+  input {
+    File inpf
+    String prefix
+  }
+  call M.md5sum as md5 {
+    input:
+      in_file = inpf,
+      prefix = prefix
+  }
+  output {
+    File md5_res = md5.out_file
+  }
+}

--- a/examples/cromwell/tools/md5sum.wdl
+++ b/examples/cromwell/tools/md5sum.wdl
@@ -1,0 +1,22 @@
+version development
+
+task md5sum {
+  input {
+    File in_file
+    String prefix
+  }
+
+  command {
+    md5sum ~{in_file} > ~{prefix}.md5.txt
+  }
+
+  runtime {
+    cpu: 1
+    disks: "local-disk 10 SSD"
+    docker: "ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956"
+    memory: "1G"
+  }
+  output {
+    File out_file = "~{prefix}.md5.txt"
+  }
+}


### PR DESCRIPTION
Adding an md5sum task with an explicit output. You can call this as e.g. (--edited based on comments) 

```
curl --location \
    --request POST 'https://server-a2pko7ameq-ts.a.run.app/cromwell' \
    --header "Authorization: Bearer $(gcloud auth print-identity-token)" \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "output": "pdiakumis/analysis-runner-test",
        "dataset": "fewgenomes",
        "repo": "analysis-runner",
        "accessLevel": "test",
        "commit": "20ab067d1d89cbfd1f3db9e49149edd7b88ccc2e",
        "inputs_dict": {
            "md5sum.prefix": "sampleB",
            "md5sum.inpf": "gs://cpg-fewgenomes-test/gvcf/batch0/NA19983.g.vcf.gz.tbi"
        },
        "input_json_paths": [],
        "workflow": "md5sum_wf.wdl",
        "dependencies": ["tools"],
        "cwd": "examples/cromwell",
        "description": "md5sum on a GVCF index"
    }'
```

@illusional the `commit` above is part of this PR so I guess it will get lost if you're looking for it in the commit history, correct? I couldn't find commit `74f91a3a246fbba261f1c2a3e06bc847c77b89cf` as shown in the README example in the `main` branch history.