### PR TITLE
Bump version: (to re-release) Add missing conda dependencies

### DIFF
--- a/conda/analysis-runner/meta.yaml
+++ b/conda/analysis-runner/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - google-auth ==1.24.0
     - click ==7.1.2
     - requests
+    - tabulate
 
 test:
   commands:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -21,6 +21,7 @@ dependencies:
   - python=3.7
   - bump2version
   - requests
+  - tabulate
   - pip
   - pip:
     - airtable-python-wrapper==0.15.1


### PR DESCRIPTION
To fix the CI: https://github.com/populationgenomics/analysis-runner/runs/3024547558

Do you think there are other new dependencies in the Cromwell update that we need to specify?