### PR TITLE
Allow reading from the upload bucket

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -314,6 +314,13 @@ def main():  # pylint: disable=too-many-locals
     )
 
     add_bucket_permissions(
+        'access-group-upload-bucket-viewer',
+        access_group,
+        upload_bucket,
+        'roles/storage.objectViewer',
+    )
+
+    add_bucket_permissions(
         'access-group-main-metadata-bucket-viewer',
         access_group,
         main_metadata_bucket,


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C01DNQ1E109/p1626825161235200

A corresponding `team-docs` storage policies update will follow in a separate PR.

@pdiakumis FYI