### PR TITLE
Use cpg-utils functions for reading / writing secrets

### DIFF
--- a/access_group_cache/Dockerfile
+++ b/access_group_cache/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.9-slim
+
+ENV PYTHONUNBUFFERED True
+
+ENV MAMBA_ROOT_PREFIX /root/micromamba
+ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
+
+RUN apt-get update && apt-get install -y wget bzip2 && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/* && \
+    wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
+    mkdir $MAMBA_ROOT_PREFIX && \
+    micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c cpg -c conda-forge \
+    cpg-utils==2.1.0 aiohttp flask gunicorn && \
+    rm -r /root/micromamba/pkgs
+
+COPY main.py ./
+
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/access_group_cache/Dockerfile
+++ b/access_group_cache/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c cpg -c conda-forge \
-    cpg-utils==2.1.0 aiohttp flask gunicorn && \
+    cpg-utils==2.1.1 aiohttp flask gunicorn && \
     rm -r /root/micromamba/pkgs
 
 COPY main.py ./

--- a/access_group_cache/README.md
+++ b/access_group_cache/README.md
@@ -2,16 +2,17 @@
 
 For inexplicable reasons, a Google Groups [`groups.lookup`](https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups/lookup) and [`groups.memberships.lookup`](https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups.memberships/lookup) REST call takes longer than 1.5s each from the `australia-southeast1` zone. In the US, it's a little faster, at 0.7s.
 
-In order to avoid this surprisingly high latency, this Cloud Function stores group membership lists in a separate secret per group. When invoked like a Cron job through Cloud Scheduler, those secrets can therefore act as a reasonably fast cache to facilitate membership checks.
+In order to avoid this surprisingly high latency, this Cloud Run deployment stores group membership lists in a separate secret per group. When invoked like a Cron job through Cloud Scheduler, those secrets can therefore act as a reasonably fast cache to facilitate membership checks.
 
 To deploy, run:
 
 ```bash
-gcloud functions deploy access_group_cache \
+gcloud beta run deploy access-group-cache \
+  --source . \
   --project=analysis-runner \
   --region=australia-southeast1 \
-  --runtime=python39 \
-  --memory=1024MB \
-  --trigger-topic=access-group-cache-refresh \
+  --no-allow-unauthenticated \
   --service-account=access-group-cache@analysis-runner.iam.gserviceaccount.com
 ```
+
+The `access-group-cache-refresh` Pub/Sub topic is configured to [trigger](https://cloud.google.com/run/docs/triggering/pubsub-push) the Cloud Run endpoint.

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -6,7 +6,7 @@ import urllib
 import os
 from typing import Dict, List, Optional
 import aiohttp
-import cpg_utils
+import cpg_utils.cloud
 from flask import Flask
 
 PROJECT_ID = 'analysis-runner'

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -5,27 +5,9 @@ import json
 import urllib
 from typing import Dict, List, Optional
 import aiohttp
-from google.cloud import secretmanager
-import google.api_core.exceptions
+import cpg_utils
 
 PROJECT_ID = 'analysis-runner'
-
-secret_manager = secretmanager.SecretManagerServiceClient()
-
-
-def _read_secret(name: str) -> Optional[str]:
-    """Reads the latest version of the given secret from Google's Secret Manager."""
-    try:
-        response = secret_manager.access_secret_version(
-            request={
-                'name': f'{secret_manager.secret_path(PROJECT_ID, name)}/versions/latest'
-            }
-        )
-    except google.api_core.exceptions.ClientError as e:
-        # Fail gracefully if there's no secret version yet.
-        print(f'Problem accessing secret {name}: {e}')
-        return None
-    return response.payload.data.decode('UTF-8')
 
 
 async def _groups_lookup(access_token: str, group_name: str) -> Optional[str]:
@@ -137,7 +119,7 @@ async def _get_dataset_access_group_members(
 def access_group_cache(unused_data, unused_context):
     """Cloud Function entry point."""
 
-    config = json.loads(_read_secret('server-config'))
+    config = json.loads(cpg_utils.read_secret(PROJECT_ID, 'server-config'))
 
     # Google Groups API queries are ridiculously slow, on the order of a few hundred ms
     # per query. That's why we use async processing here to keep processing times low.
@@ -148,17 +130,10 @@ def access_group_cache(unused_data, unused_context):
 
         # Check whether the current secret version is up-to-date.
         secret_name = f'{dataset}-access-members-cache'
-        current_secret = _read_secret(secret_name)
+        current_secret = cpg_utils.read_secret(PROJECT_ID, secret_name)
 
         if current_secret == secret_value:
-            print(f'Cache for {dataset} is up-to-date.')
-            continue  # Nothing left to do.
-
-        response = secret_manager.add_secret_version(
-            request={
-                'parent': secret_manager.secret_path(PROJECT_ID, secret_name),
-                'payload': {'data': secret_value.encode('UTF-8')},
-            }
-        )
-
-        print(f'Added secret version: {response.name}')
+            print(f'Secret {secret_name} is up-to-date')
+        else:
+            cpg_utils.write_secret(PROJECT_ID, secret_name, secret_value)
+            print(f'Updated secret {secret_name}')

--- a/access_group_cache/requirements.txt
+++ b/access_group_cache/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-google-cloud-secret-manager
+cpg_utils

--- a/access_group_cache/requirements.txt
+++ b/access_group_cache/requirements.txt
@@ -1,2 +1,0 @@
-aiohttp
-cpg_utils

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -243,10 +243,10 @@ def main():  # pylint: disable=too-many-locals
     )
 
     gcp.secretmanager.SecretIamMember(
-        f'access-group-cache-secret-version-adder',
+        f'access-group-cache-secret-version-manager',
         project=ANALYSIS_RUNNER_PROJECT,
         secret_id=access_group_cache_secret.id,
-        role='roles/secretmanager.secretVersionAdder',
+        role='roles/secretmanager.secretVersionManager',
         member=f'serviceAccount:{ACCESS_GROUP_CACHE_SERVICE_ACCOUNT}',
     )
 


### PR DESCRIPTION
Required moving from a Cloud Function deployment to Cloud Run, as our `cpg-utils` package is only available in Anaconda.

Depends on https://github.com/populationgenomics/cpg-utils/pull/6.