### PR TITLE
Add sample-metadata api to driver container

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \
-        hail=$HAIL_VERSION analysis-runner sample-metadata bokeh selenium phantomjs \
+        hail=$HAIL_VERSION analysis-runner sample-metadata=1.0.2 bokeh selenium phantomjs \
         r-base=4.0.3 r-essentials r-tidyverse && \
     rm -r /root/micromamba/pkgs && \
     # hailctl dataproc uses gcloud beta dataproc.

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \
-        hail=$HAIL_VERSION analysis-runner bokeh selenium phantomjs \
+        hail=$HAIL_VERSION analysis-runner sample-metadata bokeh selenium phantomjs \
         r-base=4.0.3 r-essentials r-tidyverse && \
     rm -r /root/micromamba/pkgs && \
     # hailctl dataproc uses gcloud beta dataproc.


### PR DESCRIPTION
- Fixed sample-metadata conda deploy (in 1.0.2)
- Add sample-metadata to make it simpler for analysis tasks to update sample-metadata database.