### PR TITLE
Use cpg_utils.cloud.read_secret to avoid duplicating code

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ ARG DRIVER_IMAGE
 FROM ${DRIVER_IMAGE}
 
 RUN micromamba install --prefix $MAMBA_ROOT_PREFIX -c cpg -c conda-forge \
-    cpg-utils==2.0.0 \
+    cpg-utils==2.1.1 \
     google-api-python-client==2.10.0 \
     google-cloud-secret-manager==2.2.0 \
     google-cloud-pubsub==2.3.0 \


### PR DESCRIPTION
Should be a no-op functionally.