### PR TITLE
Allow gatk-sv repo

### DIFF
--- a/tokens/main.py
+++ b/tokens/main.py
@@ -11,10 +11,16 @@ from google.cloud import secretmanager
 ALLOWED_REPOS = {
     'acute-care': [],
     'ancestry': ['ancestry'],
-    'fewgenomes': ['analysis-runner', 'fewgenomes', 'joint-calling', 'sv-workflows'],
+    'fewgenomes': [
+        'analysis-runner',
+        'fewgenomes',
+        'joint-calling',
+        'sv-workflows',
+        'gatk-sv',
+    ],
     'seqr': ['hail-elasticsearch-pipelines'],
     'thousand-genomes': [],
-    'tob-wgs': ['ancestry', 'joint-calling', 'tob-wgs', 'sv-workflows'],
+    'tob-wgs': ['ancestry', 'joint-calling', 'tob-wgs', 'sv-workflows', 'gatk-sv'],
 }
 
 GCP_PROJECT = 'analysis-runner'


### PR DESCRIPTION
For running code directly from <https://github.com/populationgenomics/gatk-sv>, instead of working with git submodules.