### PR TITLE
README: use fewgenomes, not tob-wgs

### DIFF
--- a/analysis_runner/analysisrunner.py
+++ b/analysis_runner/analysisrunner.py
@@ -143,7 +143,7 @@ def _perform_shebang_check(script):
     """
     Returns None if script has shebang, otherwise raises Exception
     """
-    with open(script) as f:
+    with open(script, encoding='utf-8') as f:
         potential_shebang = f.readline()
         if potential_shebang.startswith('#!'):
             return

--- a/examples/r/README.md
+++ b/examples/r/README.md
@@ -7,17 +7,16 @@ the specified output GCS bucket.
 ```bash
 cd examples/r
 
+dataset="fewgenomes"
+outdir="$(whoami)-test-r-1"
 # make sure you've installed https://anaconda.org/cpg/analysis-runner
 analysis-runner \
   --access-level "test" \
-  --dataset "tob-wgs" \
+  --dataset ${dataset} \
   --description "testing R" \
-  --output-dir "$(whoami)-test-r" \
+  --output-dir ${outdir} \
   script.R
-```
 
-Check that the output GCS bucket contains the files:
-
-```bash
-gsutil ls gs://cpg-tob-wgs-test-tmp/$(whoami)-test-r/
+# Check that the output GCS bucket contains the files:
+gsutil ls gs://cpg-${dataset}-test-tmp/${outdir}
 ```

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ PKG = 'analysis-runner'
 
 def read_file(filename: str) -> str:
     """Returns the full contents of the given file."""
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         return f.read()
 
 

--- a/tokens/main.py
+++ b/tokens/main.py
@@ -46,7 +46,7 @@ def get_token(hail_user: str) -> str:
 
 def get_project_id(dataset: str) -> str:
     """Returns the GCP project ID associated with the given dataset."""
-    with open(f'../stack/Pulumi.{dataset}.yaml') as f:
+    with open(f'../stack/Pulumi.{dataset}.yaml', encoding='utf-8') as f:
         return yaml.safe_load(f)['config']['gcp:project']
 
 


### PR DESCRIPTION
Just a fix in the README - analysis-runner doesn't have access to tob-wgs, so changed it to fewgenomes.
A couple linting errors in the actions (from unrelated code) have popped up, so not sure if I should fix those here as well..