### PR TITLE
Add sample-metadata access permissions

### DIFF
--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -121,9 +121,6 @@ def index():
         cpg_utils.cloud.read_secret(ANALYSIS_RUNNER_PROJECT_ID, 'server-config')
     )
 
-    # key = f'sample-metadata-{env}-{rs}'
-    # secret_id = f'{dataset}-{key}-members-cache'
-
     group_types = [
         'access',
         'web-access',

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -131,7 +131,7 @@ def index():
     # add SM group types
     group_types.extend(
         f'sample-metadata-{env}-{rs}'
-        for env in ('production', 'test')
+        for env in ('main', 'test')
         for rs in ('read', 'write')
     )
 

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -121,10 +121,27 @@ def index():
         cpg_utils.cloud.read_secret(ANALYSIS_RUNNER_PROJECT_ID, 'server-config')
     )
 
+    # key = f'sample-metadata-{env}-{rs}'
+    # secret_id = f'{dataset}-{key}-members-cache'
+
+    group_types = [
+        'access',
+        'web-access',
+        'test',
+        'standard',
+        'full',
+    ]
+    # add SM group types
+    group_types.extend(
+        f'sample-metadata-{env}-{rs}'
+        for env in ('production', 'test')
+        for rs in ('read', 'write')
+    )
+
     groups = []
     dataset_by_group = {}
     for dataset in config:
-        for group_type in 'access', 'web-access', 'test', 'standard', 'full':
+        for group_type in group_types:
             group = f'{dataset}-{group_type}'
             groups.append(group)
             dataset_by_group[group] = dataset

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -247,7 +247,6 @@ def main():  # pylint: disable=too-many-locals
         )
 
     def add_access_group_cache_as_secret_member(secret, resource_prefix: str):
-
         gcp.secretmanager.SecretIamMember(
             f'{resource_prefix}-group-cache-secret-accessor',
             secret_id=secret.id,

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -344,7 +344,7 @@ def main():  # pylint: disable=too-many-locals
 
             gcp.cloudidentity.GroupMembership(
                 f'sample-metadata-group-cache-{env}-{rs}-access-level-group-membership',
-                group=group.id,
+                group=group,
                 preferred_member_key=gcp.cloudidentity.GroupMembershipPreferredMemberKeyArgs(
                     id=SAMPLE_METADATA_API_SERVICE_ACCOUNT
                 ),
@@ -375,14 +375,18 @@ def main():  # pylint: disable=too-many-locals
             )
 
     sm_access_levels = [
-        ('person', access_group, ('production-read', 'test-read', 'test-write')),
-        ('test', access_level_groups['test'], ('test-read', 'test-write')),
+        (
+            'person',
+            access_group.group_key.id,
+            ('production-read', 'test-read', 'test-write'),
+        ),
+        ('test', access_level_groups['test'].group_key.id, ('test-read', 'test-write')),
         (
             'standard',
-            access_level_groups['standard'],
+            access_level_groups['standard'].group_key.id,
             ('production-read', 'production-write'),
         ),
-        ('full', access_level_groups['full'], sm_groups.keys()),
+        ('full', access_level_groups['full'].group_key.id, sm_groups.keys()),
     ]
 
     # give humans (access_group) access to:

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -394,7 +394,7 @@ def main():  # pylint: disable=too-many-locals
     # Declare access to sample-metadata API of format ({env}-{read,write})
     sm_access_levels: List[SampleMetadataAccessorMembership] = [
         SampleMetadataAccessorMembership(
-            name='person',
+            name='human',
             service_account=access_group.group_key.id,
             permissions=('main-read', 'test-read', 'test-write'),
         ),


### PR DESCRIPTION
Adds 4 groups and secrets for production-read, production-write, test-read, test-write, and implementing the following table:

![image](https://user-images.githubusercontent.com/22381693/131423258-365d3ed9-cada-4ecb-b0c0-b19516ba745d.png)

I believe the depends_on relationships should be transitively carried when the groups are resolved.