### PR TITLE
Disable versioning on metadata buckets

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -186,9 +186,7 @@ def main():  # pylint: disable=too-many-locals
 
     # TODO(@lgruen): delete after `metadata` data has been moved to `analysis`.
     test_metadata_bucket = create_bucket(
-        bucket_name('test-metadata'),
-        enable_versioning=False,
-        lifecycle_rules=[undelete_rule],
+        bucket_name('test-metadata'), enable_versioning=False
     )
 
     test_analysis_bucket = create_bucket(
@@ -216,9 +214,7 @@ def main():  # pylint: disable=too-many-locals
 
     # TODO(@lgruen): delete after `metadata` data has been moved to `analysis`.
     main_metadata_bucket = create_bucket(
-        bucket_name('main-metadata'),
-        enable_versioning=False,
-        lifecycle_rules=[undelete_rule],
+        bucket_name('main-metadata'), enable_versioning=False
     )
 
     main_analysis_bucket = create_bucket(

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -186,7 +186,9 @@ def main():  # pylint: disable=too-many-locals
 
     # TODO(@lgruen): delete after `metadata` data has been moved to `analysis`.
     test_metadata_bucket = create_bucket(
-        bucket_name('test-metadata'), lifecycle_rules=[undelete_rule]
+        bucket_name('test-metadata'),
+        enable_versioning=False,
+        lifecycle_rules=[undelete_rule],
     )
 
     test_analysis_bucket = create_bucket(
@@ -214,7 +216,9 @@ def main():  # pylint: disable=too-many-locals
 
     # TODO(@lgruen): delete after `metadata` data has been moved to `analysis`.
     main_metadata_bucket = create_bucket(
-        bucket_name('main-metadata'), lifecycle_rules=[undelete_rule]
+        bucket_name('main-metadata'),
+        enable_versioning=False,
+        lifecycle_rules=[undelete_rule],
     )
 
     main_analysis_bucket = create_bucket(


### PR DESCRIPTION
In preparation for deleting the bucket. Otherwise even removing all files will leave remaining inactive versions, which will prevent Pulumi from destroying the bucket.