### PR TITLE
Add functions to start, submit and stop Dataproc clusters separately

### DIFF
--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -44,7 +44,7 @@ class DataprocCluster:
         script: str,
         job_name: Optional[str] = None,
         pyfiles: Optional[List[str]] = None,
-    ):
+    ) -> hb.batch.job.Job:
         """
         Create a job that submits the `script` to the cluster
         """
@@ -57,6 +57,7 @@ class DataprocCluster:
         )
         job.depends_on(self.start_job)
         self.stop_job.depends_on(job)
+        return job
 
 
 def hail_dataproc(

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -2,7 +2,6 @@
 
 import os
 import uuid
-import contextlib
 from typing import Optional, List, Dict, Tuple
 import hailtop.batch as hb
 from analysis_runner.git import (
@@ -40,7 +39,7 @@ class DataprocCluster:
         self.stop_job = stop_job
         self.cluster_name = cluster_name
 
-    def submit(
+    def add_job(
         self,
         script: str,
         job_name: Optional[str] = None,
@@ -60,7 +59,6 @@ class DataprocCluster:
         self.stop_job.depends_on(submit_job)
 
 
-@contextlib.contextmanager
 def hail_dataproc(
     batch: hb.Batch,
     *,
@@ -78,7 +76,7 @@ def hail_dataproc(
     job_name: Optional[str] = None,
     scopes: Optional[List[str]] = None,
     labels: Optional[Dict[str, str]] = None,
-) -> hb.batch.job.Job:
+) -> DataprocCluster:
     """
     Adds jobs to the batch that start and stop a Dataproc cluster, and returns
     a DataprocCluster object with a submit() method that allows to add jobs into
@@ -115,11 +113,9 @@ def hail_dataproc(
     )
     stop_job.depends_on(start_job)
 
-    yield DataprocCluster(
+    return DataprocCluster(
         batch=batch, start_job=start_job, stop_job=stop_job, cluster_name=cluster_name
     )
-
-    return stop_job
 
 
 def hail_dataproc_job(

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -129,6 +129,7 @@ def hail_dataproc_job(
     """
     A legacy wrapper that adds a start, submit, and stop job altogether
     """
+    kwargs['job_name'] = job_name
     cluster = setup_dataproc(*args, **kwargs)
     return cluster.add_job(script, job_name, pyfiles)
 

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -48,15 +48,15 @@ class DataprocCluster:
         """
         Create a job that submits the `script` to the cluster
         """
-        submit_job = _submit_to_cluster(
+        job = _add_submit_job(
             batch=self.batch,
             cluster_name=self.cluster_name,
             script=script,
             job_name=job_name,
             pyfiles=pyfiles,
         )
-        submit_job.depends_on(self.start_job)
-        self.stop_job.depends_on(submit_job)
+        job.depends_on(self.start_job)
+        self.stop_job.depends_on(job)
 
 
 def hail_dataproc(
@@ -87,7 +87,7 @@ def hail_dataproc(
     depends_on can be used to enforce dependencies for the new job.
     """
 
-    start_job, cluster_name = _start_cluster(
+    start_job, cluster_name = _add_start_job(
         batch=batch,
         max_age=max_age,
         num_workers=num_workers,
@@ -106,7 +106,7 @@ def hail_dataproc(
     if depends_on:
         start_job.depends_on(*depends_on)
 
-    stop_job = _stop_cluster(
+    stop_job = _add_stop_job(
         batch=batch,
         cluster_name=cluster_name,
         job_name=job_name,
@@ -143,7 +143,7 @@ def hail_dataproc_job(
     information on the keyword parameters. depends_on can be used to enforce
     dependencies for the new job."""
 
-    start_job, cluster_name = _start_cluster(
+    start_job, cluster_name = _add_start_job(
         batch=batch,
         max_age=max_age,
         num_workers=num_workers,
@@ -162,7 +162,7 @@ def hail_dataproc_job(
     if depends_on:
         start_job.depends_on(*depends_on)
 
-    main_job = _submit_to_cluster(
+    main_job = _add_submit_job(
         batch=batch,
         cluster_name=cluster_name,
         script=script,
@@ -171,7 +171,7 @@ def hail_dataproc_job(
     )
     main_job.depends_on(start_job)
 
-    stop_job = _stop_cluster(
+    stop_job = _add_stop_job(
         batch=batch,
         cluster_name=cluster_name,
         job_name=job_name,
@@ -181,7 +181,7 @@ def hail_dataproc_job(
     return stop_job
 
 
-def _start_cluster(
+def _add_start_job(
     batch: hb.Batch,
     *,
     max_age: str,
@@ -263,7 +263,7 @@ def _start_cluster(
     return start_job, cluster_name
 
 
-def _submit_to_cluster(
+def _add_submit_job(
     batch: hb.Batch,
     cluster_name: str,
     script: str,
@@ -311,7 +311,7 @@ def _submit_to_cluster(
     return main_job
 
 
-def _stop_cluster(
+def _add_stop_job(
     batch: hb.Batch,
     cluster_name: str,
     job_name: Optional[str] = None,

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -130,8 +130,7 @@ def hail_dataproc_job(
     A legacy wrapper that adds a start, submit, and stop job altogether
     """
     cluster = setup_dataproc(*args, **kwargs)
-    cluster.add_job(script, job_name, pyfiles)
-    return cluster._stop_job  # pylint: disable=protected-access
+    return cluster.add_job(script, job_name, pyfiles)
 
 
 def _add_start_job(

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -120,8 +120,8 @@ def setup_dataproc(
 
 
 def hail_dataproc_job(
+    batch: hb.Batch,
     script: str,
-    *args,
     pyfiles: Optional[List[str]] = None,
     job_name: Optional[str] = None,
     **kwargs,
@@ -130,7 +130,7 @@ def hail_dataproc_job(
     A legacy wrapper that adds a start, submit, and stop job altogether
     """
     kwargs['job_name'] = job_name
-    cluster = setup_dataproc(*args, **kwargs)
+    cluster = setup_dataproc(batch, **kwargs)
     return cluster.add_job(script, job_name, pyfiles)
 
 

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -34,10 +34,10 @@ class DataprocCluster:
         stop_job: hb.batch.job.Job,
         cluster_name: str,
     ):
-        self.batch = batch
-        self.start_job = start_job
-        self.stop_job = stop_job
-        self.cluster_name = cluster_name
+        self._batch = batch
+        self._start_job = start_job
+        self._stop_job = stop_job
+        self._cluster_name = cluster_name
 
     def add_job(
         self,
@@ -49,14 +49,14 @@ class DataprocCluster:
         Create a job that submits the `script` to the cluster
         """
         job = _add_submit_job(
-            batch=self.batch,
-            cluster_name=self.cluster_name,
+            batch=self._batch,
+            cluster_name=self._cluster_name,
             script=script,
             job_name=job_name,
             pyfiles=pyfiles,
         )
-        job.depends_on(self.start_job)
-        self.stop_job.depends_on(job)
+        job.depends_on(self._start_job)
+        self._stop_job.depends_on(job)
         return job
 
 
@@ -79,13 +79,13 @@ def hail_dataproc(
     labels: Optional[Dict[str, str]] = None,
 ) -> DataprocCluster:
     """
-    Adds jobs to the batch that start and stop a Dataproc cluster, and returns
-    a DataprocCluster object with a submit() method that allows to add jobs into
-    this cluster that submit Query scripts.
+    Adds jobs to the Batch that start and stop a Dataproc cluster, and returns
+    a DataprocCluster object with an add_job() method, that inserts a job
+    between start and stop.
 
     See the `hailctl` tool for information on the keyword parameters.
 
-    depends_on can be used to enforce dependencies for the new job.
+    `depends_on` can be used to enforce dependencies for the cluster start up.
     """
 
     start_job, cluster_name = _add_start_job(

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -12,14 +12,24 @@ service_backend = hb.ServiceBackend(
 
 batch = hb.Batch(name='dataproc example', backend=service_backend)
 
-dataproc.hail_dataproc_job(
+with dataproc.hail_dataproc(
     batch,
-    'query.py',
     max_age='1h',
     packages=['click', 'selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
-    job_name='example',
-)
+) as dp:
+    dp.submit('query.py', job_name='example 1')
+    dp.submit('query.py', job_name='example 2')
+
+
+# dataproc.hail_dataproc_job(
+#     batch,
+#     'query.py',
+#     max_age='1h',
+#     packages=['click', 'selenium'],
+#     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+#     job_name='example',
+# )
 
 # Don't wait, which avoids resubmissions if this job gets preempted.
 batch.run(wait=False)

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -13,7 +13,7 @@ service_backend = hb.ServiceBackend(
 batch = hb.Batch(name='dataproc example', backend=service_backend)
 
 
-cluster = dataproc.hail_dataproc(
+cluster = dataproc.setup_dataproc(
     batch,
     max_age='1h',
     packages=['click', 'selenium'],

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -12,14 +12,15 @@ service_backend = hb.ServiceBackend(
 
 batch = hb.Batch(name='dataproc example', backend=service_backend)
 
-with dataproc.hail_dataproc(
+
+cluster = dataproc.hail_dataproc(
     batch,
     max_age='1h',
     packages=['click', 'selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
-) as dp:
-    dp.submit('query.py', job_name='example 1')
-    dp.submit('query.py', job_name='example 2')
+)
+cluster.add_job('query.py', job_name='example 1')
+cluster.add_job('query.py', job_name='example 2')
 
 
 # dataproc.hail_dataproc_job(

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -18,7 +18,7 @@ cluster = dataproc.setup_dataproc(
     max_age='1h',
     packages=['click', 'selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
-    cluster_title='My Cluster',
+    cluster_name='My Cluster',
 )
 cluster.add_job('query.py', job_name='example')
 

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -19,18 +19,8 @@ cluster = dataproc.hail_dataproc(
     packages=['click', 'selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
 )
-cluster.add_job('query.py', job_name='example 1')
-cluster.add_job('query.py', job_name='example 2')
+cluster.add_job('query.py', job_name='example')
 
-
-# dataproc.hail_dataproc_job(
-#     batch,
-#     'query.py',
-#     max_age='1h',
-#     packages=['click', 'selenium'],
-#     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
-#     job_name='example',
-# )
 
 # Don't wait, which avoids resubmissions if this job gets preempted.
 batch.run(wait=False)

--- a/examples/dataproc/main.py
+++ b/examples/dataproc/main.py
@@ -18,6 +18,7 @@ cluster = dataproc.setup_dataproc(
     max_age='1h',
     packages=['click', 'selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    cluster_title='My Cluster',
 )
 cluster.add_job('query.py', job_name='example')
 


### PR DESCRIPTION
Being able to start a cluster once and submit multiple jobs consequently would benefit a lot the joint-calling pipeline a lot, as it currently submits lots of hail query scripts, each of them involving creating almost identical clusters.