### PR TITLE
Disable specifying project for requester pays

### DIFF
--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -211,7 +211,8 @@ def add_cromwell_routes(
             workflow_options = {
                 'user_service_account_json': service_account_json,
                 'google_compute_service_account': service_account_email,
-                'google_project': project,
+                # for requester pays
+                # 'google_project': project,
                 'jes_gcs_root': intermediate_dir,
                 'final_workflow_outputs_dir': workflow_output_dir,
                 'google_labels': google_labels,


### PR DESCRIPTION
[Source for disabling requester pays](https://cromwell.readthedocs.io/en/stable/filesystems/GoogleCloudStorage/#:~:text=If%20a%20google_project%20was%20set%20in%20the%20workflow%20options%20when%20the%20workflow%20was%20submitted%2C%20this%20value%20is%20used).

1. If a `google_project` was set in the workflow options when the workflow was submitted, this value is used
2. Otherwise, the value of the `project` field in the gcs filesystem configuration is used
3. If the machine Cromwell runs on is authenticated using gcloud and a default project is set, this value will be used