### PR TITLE
Add 'main-read' permissions to test accounts

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -397,7 +397,7 @@ def main():  # pylint: disable=too-many-locals
         SampleMetadataAccessorMembership(
             name='test',
             member_key=access_level_groups['test'].group_key.id,
-            permissions=('test-read', 'test-write'),
+            permissions=('main-read', 'test-read', 'test-write'),
         ),
         SampleMetadataAccessorMembership(
             name='standard',


### PR DESCRIPTION
Stop gap until a proper migration is written.