### PR TITLE
Improve error messages of analysis-runner requests

### DIFF
--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -4,7 +4,6 @@ Exports 'add_cromwell_routes', to add the following route to a flask API:
     POST /cromwell: Posts a workflow to a cromwell_url
 """
 import json
-import logging
 import subprocess
 from datetime import datetime
 from shlex import quote
@@ -29,6 +28,17 @@ from util import (
     DRIVER_IMAGE,
     get_cromwell_key,
 )
+
+CROMWELL_REQUIRED_PARAMS = [
+    'accessLevel',
+    'commit',
+    'cwd',
+    'dataset',
+    'description',
+    'output',
+    'repo',
+    'workflow',
+]
 
 
 def add_cromwell_routes(
@@ -94,165 +104,166 @@ def add_cromwell_routes(
         # When accessing a missing entry in the params dict, the resulting KeyError
         # exception gets translated to a Bad Request error in the try block below.
         params = await request.json()
-        try:
-            server_config = get_server_config()
-            output_dir = validate_output_dir(params['output'])
-            dataset = params['dataset']
-            check_dataset_and_group(server_config, dataset, email)
-            repo = params['repo']
-            check_allowed_repos(server_config, dataset, repo)
-            access_level = params['accessLevel']
-            labels = params.get('labels')
 
-            ds_config = server_config[dataset]
-            project = ds_config.get('projectId')
-            hail_token = ds_config.get(f'{access_level}Token')
-            service_account_json = get_cromwell_key(
-                dataset=dataset, access_level=access_level
-            )
-            # use the email specified by the service_account_json again
-            service_account_dict = json.loads(service_account_json)
-            service_account_email = service_account_dict.get('client_email')
-            if not service_account_email:
-                raise web.HTTPServerError(
-                    reason="The service_account didn't contain an entry for client_email"
-                )
-
-            if access_level == 'test':
-                intermediate_dir = f'gs://cpg-{dataset}-test-tmp/cromwell'
-                workflow_output_dir = f'gs://cpg-{dataset}-test/{output_dir}'
-            else:
-                intermediate_dir = f'gs://cpg-{dataset}-main-tmp/cromwell'
-                workflow_output_dir = f'gs://cpg-{dataset}-main/{output_dir}'
-
-            hail_bucket = f'cpg-{dataset}-hail'
-            backend = hb.ServiceBackend(
-                billing_project=dataset,
-                bucket=hail_bucket,
-                token=hail_token,
+        missing_params = [key for key in CROMWELL_REQUIRED_PARAMS if key not in params]
+        if missing_params:
+            raise ValueError(
+                'Missing request parameter(s): ' + ', '.join(missing_params)
             )
 
-            commit = params['commit']
-            if not commit or commit == 'HEAD':
-                raise web.HTTPBadRequest(reason='Invalid commit parameter')
+        server_config = get_server_config()
+        output_dir = validate_output_dir(params['output'])
+        dataset = params['dataset']
+        check_dataset_and_group(server_config, dataset, email)
+        repo = params['repo']
+        check_allowed_repos(server_config, dataset, repo)
+        access_level = params['accessLevel']
+        labels = params.get('labels')
 
-            libs = params.get('dependencies')
-            if not isinstance(libs, list):
-                raise web.HTTPBadRequest(reason='Expected "dependencies" to be a list')
-            cwd = params['cwd']
-            wf = params['workflow']
-            if not wf:
-                raise web.HTTPBadRequest(reason='Invalid script parameter')
-
-            input_jsons = params.get('input_json_paths') or []
-            input_dict = params.get('inputs_dict')
-
-            # This metadata dictionary gets stored at the output_dir location.
-            timestamp = datetime.now().astimezone().isoformat()
-            metadata = json.dumps(
-                get_analysis_runner_metadata(
-                    timestamp=timestamp,
-                    dataset=dataset,
-                    user=email,
-                    access_level=access_level,
-                    repo=repo,
-                    commit=commit,
-                    script=wf,
-                    description=params['description'],
-                    output_suffix=workflow_output_dir,
-                    driver_image=DRIVER_IMAGE,
-                    cwd=cwd,
-                    mode='cromwell',
-                )
+        ds_config = server_config[dataset]
+        project = ds_config.get('projectId')
+        hail_token = ds_config.get(f'{access_level}Token')
+        service_account_json = get_cromwell_key(
+            dataset=dataset, access_level=access_level
+        )
+        # use the email specified by the service_account_json again
+        service_account_dict = json.loads(service_account_json)
+        service_account_email = service_account_dict.get('client_email')
+        if not service_account_email:
+            raise web.HTTPServerError(
+                reason="The service_account didn't contain an entry for client_email"
             )
 
-            # Publish the metadata to Pub/Sub. Wait for the result before running the batch.
-            publisher.publish(PUBSUB_TOPIC, metadata.encode('utf-8')).result()
+        if access_level == 'test':
+            intermediate_dir = f'gs://cpg-{dataset}-test-tmp/cromwell'
+            workflow_output_dir = f'gs://cpg-{dataset}-test/{output_dir}'
+        else:
+            intermediate_dir = f'gs://cpg-{dataset}-main-tmp/cromwell'
+            workflow_output_dir = f'gs://cpg-{dataset}-main/{output_dir}'
 
-            user_name = email.split('@')[0]
-            batch_name = f'{user_name} {repo}:{commit}/cromwell/{wf}'
+        hail_bucket = f'cpg-{dataset}-hail'
+        backend = hb.ServiceBackend(
+            billing_project=dataset,
+            bucket=hail_bucket,
+            token=hail_token,
+        )
 
-            batch = hb.Batch(
-                backend=backend, name=batch_name, requester_pays_project=project
-            )
+        commit = params['commit']
+        if not commit or commit == 'HEAD':
+            raise web.HTTPBadRequest(reason='Invalid commit parameter')
 
-            job = batch.new_job(name='driver')
-            job = prepare_git_job(
-                job=job,
+        libs = params.get('dependencies')
+        if not isinstance(libs, list):
+            raise web.HTTPBadRequest(reason='Expected "dependencies" to be a list')
+        cwd = params['cwd']
+        wf = params['workflow']
+        if not wf:
+            raise web.HTTPBadRequest(reason='Invalid script parameter')
+
+        input_jsons = params.get('input_json_paths') or []
+        input_dict = params.get('inputs_dict')
+
+        # This metadata dictionary gets stored at the output_dir location.
+        timestamp = datetime.now().astimezone().isoformat()
+        metadata = json.dumps(
+            get_analysis_runner_metadata(
+                timestamp=timestamp,
                 dataset=dataset,
+                user=email,
                 access_level=access_level,
-                output_suffix=output_dir,
                 repo=repo,
                 commit=commit,
-                metadata_str=metadata,
-                print_all_statements=False,
+                script=wf,
+                description=params['description'],
+                output_suffix=workflow_output_dir,
+                driver_image=DRIVER_IMAGE,
+                cwd=cwd,
+                mode='cromwell',
             )
-            job.env('OUTPUT', output_dir)
+        )
 
-            if cwd:
-                job.command(f'cd {quote(cwd)}')
+        # Publish the metadata to Pub/Sub. Wait for the result before running the batch.
+        publisher.publish(PUBSUB_TOPIC, metadata.encode('utf-8')).result()
 
-            deps_path = None
-            if libs:
-                deps_path = 'tools.zip'
-                job.command(
-                    'zip -r tools.zip ' + ' '.join(quote(s + '/') for s in libs)
-                )
+        user_name = email.split('@')[0]
+        batch_name = f'{user_name} {repo}:{commit}/cromwell/{wf}'
 
-            cromwell_post_url = CROMWELL_URL + '/api/workflows/v1'
+        batch = hb.Batch(
+            backend=backend, name=batch_name, requester_pays_project=project
+        )
 
-            google_labels = {}
+        job = batch.new_job(name='driver')
+        job = prepare_git_job(
+            job=job,
+            dataset=dataset,
+            access_level=access_level,
+            output_suffix=output_dir,
+            repo=repo,
+            commit=commit,
+            metadata_str=metadata,
+            print_all_statements=False,
+        )
+        job.env('OUTPUT', output_dir)
 
-            if labels:
-                google_labels.update(labels)
+        if cwd:
+            job.command(f'cd {quote(cwd)}')
 
-            google_labels.update({'compute-category': 'cromwell'})
+        deps_path = None
+        if libs:
+            deps_path = 'tools.zip'
+            job.command('zip -r tools.zip ' + ' '.join(quote(s + '/') for s in libs))
 
-            workflow_options = {
-                'user_service_account_json': service_account_json,
-                'google_compute_service_account': service_account_email,
-                'google_project': project,
-                'jes_gcs_root': intermediate_dir,
-                'final_workflow_outputs_dir': workflow_output_dir,
-                'google_labels': google_labels,
-            }
+        cromwell_post_url = CROMWELL_URL + '/api/workflows/v1'
 
-            if input_dict:
-                tmp_input_json_path = '/tmp/inputs.json'
-                job.command(f"echo '{json.dumps(input_dict)}' > {tmp_input_json_path}")
-                input_jsons.append(tmp_input_json_path)
+        google_labels = {}
 
-            inputs_cli = []
-            for idx, value in enumerate(input_jsons):
-                key = 'workflowInputs'
-                if idx > 0:
-                    key += f'_{idx + 1}'
+        if labels:
+            google_labels.update(labels)
 
-                inputs_cli.append(f'-F "{key}=@{value}"')
+        google_labels.update({'compute-category': 'cromwell'})
 
-            job.command(
-                f"""
+        workflow_options = {
+            'user_service_account_json': service_account_json,
+            'google_compute_service_account': service_account_email,
+            'google_project': project,
+            'jes_gcs_root': intermediate_dir,
+            'final_workflow_outputs_dir': workflow_output_dir,
+            'google_labels': google_labels,
+        }
+
+        if input_dict:
+            tmp_input_json_path = '/tmp/inputs.json'
+            job.command(f"echo '{json.dumps(input_dict)}' > {tmp_input_json_path}")
+            input_jsons.append(tmp_input_json_path)
+
+        inputs_cli = []
+        for idx, value in enumerate(input_jsons):
+            key = 'workflowInputs'
+            if idx > 0:
+                key += f'_{idx + 1}'
+
+            inputs_cli.append(f'-F "{key}=@{value}"')
+
+        job.command(
+            f"""
 echo '{json.dumps(workflow_options)}' > workflow-options.json
 access_token=$(gcloud auth print-identity-token --audiences=717631777761-ec4u8pffntsekut9kef58hts126v7usl.apps.googleusercontent.com)
 wid=$(curl -X POST "{cromwell_post_url}" \\
-    -H "Authorization: Bearer $access_token" \\
-    -H "accept: application/json" \\
-    -H "Content-Type: multipart/form-data" \\
-    -F "workflowSource=@{wf}" \\
-    {' '.join(inputs_cli)} \\
-    -F "workflowOptions=@workflow-options.json;type=application/json" \\
-    {f'-F "workflowDependencies=@{deps_path}"' if deps_path else ''})
+-H "Authorization: Bearer $access_token" \\
+-H "accept: application/json" \\
+-H "Content-Type: multipart/form-data" \\
+-F "workflowSource=@{wf}" \\
+{' '.join(inputs_cli)} \\
+-F "workflowOptions=@workflow-options.json;type=application/json" \\
+{f'-F "workflowDependencies=@{deps_path}"' if deps_path else ''})
 
 echo "Submitted workflow with ID $wid"
 """
-            )
+        )
 
-            url = run_batch_job_and_print_url(batch, wait=params.get('wait', False))
+        url = run_batch_job_and_print_url(batch, wait=params.get('wait', False))
 
-            return web.Response(text=f'{url}\n')
-        except KeyError as e:
-            logging.error(e)
-            raise web.HTTPBadRequest(reason='Missing request parameter: ' + e.args[0])
+        return web.Response(text=f'{url}\n')
 
     @routes.get('/cromwell/{workflow_id}/metadata')
     async def get_cromwell_metadata(request):

--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -29,17 +29,6 @@ from util import (
     get_cromwell_key,
 )
 
-CROMWELL_REQUIRED_PARAMS = [
-    'accessLevel',
-    'commit',
-    'cwd',
-    'dataset',
-    'description',
-    'output',
-    'repo',
-    'workflow',
-]
-
 
 def add_cromwell_routes(
     routes,
@@ -104,12 +93,6 @@ def add_cromwell_routes(
         # When accessing a missing entry in the params dict, the resulting KeyError
         # exception gets translated to a Bad Request error in the try block below.
         params = await request.json()
-
-        missing_params = [key for key in CROMWELL_REQUIRED_PARAMS if key not in params]
-        if missing_params:
-            raise ValueError(
-                'Missing request parameter(s): ' + ', '.join(missing_params)
-            )
 
         server_config = get_server_config()
         output_dir = validate_output_dir(params['output'])

--- a/server/main.py
+++ b/server/main.py
@@ -38,6 +38,7 @@ ANALYSIS_RUNNER_REQUIRED_PARAMS = [
     'description',
 ]
 
+
 # pylint: disable=too-many-statements
 @routes.post('/')
 async def index(request):

--- a/server/main.py
+++ b/server/main.py
@@ -27,6 +27,16 @@ from util import (
 
 routes = web.RouteTableDef()
 
+ANALYSIS_RUNNER_REQUIRED_PARAMS = [
+    'output',
+    'dataset',
+    'repo',
+    'accessLevel',
+    'commit',
+    'cwd',
+    'script',
+    'description',
+]
 
 # pylint: disable=too-many-statements
 @routes.post('/')
@@ -37,17 +47,9 @@ async def index(request):
     # When accessing a missing entry in the params dict, the resulting KeyError
     # exception gets translated to a Bad Request error in the try block below.
     params = await request.json()
-    required_params = [
-        'output',
-        'dataset',
-        'repo',
-        'accessLevel',
-        'commit',
-        'cwd',
-        'script',
-        'description',
+    missing_params = [
+        key for key in ANALYSIS_RUNNER_REQUIRED_PARAMS if key not in params
     ]
-    missing_params = [key for key in required_params if key not in params]
     if missing_params:
         raise ValueError('Missing request parameter(s): ' + ', '.join(missing_params))
 

--- a/server/main.py
+++ b/server/main.py
@@ -206,4 +206,4 @@ async def init_func():
 
 
 if __name__ == '__main__':
-    web.run_app(init_func(), port=5050)
+    web.run_app(init_func())

--- a/server/main.py
+++ b/server/main.py
@@ -37,104 +37,115 @@ async def index(request):
     # When accessing a missing entry in the params dict, the resulting KeyError
     # exception gets translated to a Bad Request error in the try block below.
     params = await request.json()
-    try:
-        server_config = get_server_config()
-        output_suffix = validate_output_dir(params['output'])
-        dataset = params['dataset']
-        check_dataset_and_group(server_config, dataset, email)
-        repo = params['repo']
-        check_allowed_repos(server_config, dataset, repo)
+    required_params = [
+        'output',
+        'dataset',
+        'repo',
+        'accessLevel',
+        'commit',
+        'cwd',
+        'script',
+        'description',
+    ]
+    missing_params = [key for key in required_params if key not in params]
+    if missing_params:
+        raise ValueError('Missing request parameter(s): ' + ', '.join(missing_params))
 
-        access_level = params['accessLevel']
-        hail_token = server_config[dataset].get(f'{access_level}Token')
-        if not hail_token:
-            raise web.HTTPBadRequest(reason=f'Invalid access level "{access_level}"')
+    server_config = get_server_config()
+    output_suffix = validate_output_dir(params['output'])
+    dataset = params['dataset']
+    check_dataset_and_group(server_config, dataset, email)
+    repo = params['repo']
+    check_allowed_repos(server_config, dataset, repo)
 
-        hail_bucket = f'cpg-{dataset}-hail'
-        backend = hb.ServiceBackend(
-            billing_project=dataset,
-            bucket=hail_bucket,
-            token=hail_token,
-        )
+    access_level = params['accessLevel']
+    hail_token = server_config[dataset].get(f'{access_level}Token')
+    if not hail_token:
+        raise web.HTTPBadRequest(reason=f'Invalid access level "{access_level}"')
 
-        commit = params['commit']
-        if not commit or commit == 'HEAD':
-            raise web.HTTPBadRequest(reason='Invalid commit parameter')
+    hail_bucket = f'cpg-{dataset}-hail'
+    backend = hb.ServiceBackend(
+        billing_project=dataset,
+        bucket=hail_bucket,
+        token=hail_token,
+    )
 
-        cwd = params['cwd']
-        script = params['script']
-        if not script:
-            raise web.HTTPBadRequest(reason='Invalid script parameter')
+    commit = params['commit']
+    if not commit or commit == 'HEAD':
+        raise web.HTTPBadRequest(reason='Invalid commit parameter')
 
-        if not isinstance(script, list):
-            raise web.HTTPBadRequest(reason='Script parameter expects an array')
+    cwd = params['cwd']
+    script = params['script']
+    if not script:
+        raise web.HTTPBadRequest(reason='Invalid script parameter')
 
-        # This metadata dictionary gets stored in the metadata bucket, at the output_dir location.
-        hail_version = await _get_hail_version()
-        timestamp = datetime.datetime.now().astimezone().isoformat()
-        metadata = json.dumps(
-            get_analysis_runner_metadata(
-                timestamp=timestamp,
-                dataset=dataset,
-                user=email,
-                access_level=access_level,
-                repo=repo,
-                commit=commit,
-                script=' '.join(script),
-                description=params['description'],
-                output_suffix=output_suffix,
-                hailVersion=hail_version,
-                driver_image=DRIVER_IMAGE,
-                cwd=cwd,
-            )
-        )
+    if not isinstance(script, list):
+        raise web.HTTPBadRequest(reason='Script parameter expects an array')
 
-        # Publish the metadata to Pub/Sub. Wait for the result before running the batch.
-        publisher.publish(PUBSUB_TOPIC, metadata.encode('utf-8')).result()
-
-        user_name = email.split('@')[0]
-        batch_name = f'{user_name} {repo}:{commit}/{" ".join(script)}'
-
-        dataset_gcp_project = server_config[dataset]['projectId']
-        batch = hb.Batch(
-            backend=backend, name=batch_name, requester_pays_project=dataset_gcp_project
-        )
-
-        job = batch.new_job(name='driver')
-        job = prepare_git_job(
-            job=job,
+    # This metadata dictionary gets stored in the metadata bucket, at the output_dir location.
+    hail_version = await _get_hail_version()
+    timestamp = datetime.datetime.now().astimezone().isoformat()
+    metadata = json.dumps(
+        get_analysis_runner_metadata(
+            timestamp=timestamp,
             dataset=dataset,
+            user=email,
             access_level=access_level,
-            output_suffix=output_suffix,
             repo=repo,
             commit=commit,
-            metadata_str=metadata,
+            script=' '.join(script),
+            description=params['description'],
+            output_suffix=output_suffix,
+            hailVersion=hail_version,
+            driver_image=DRIVER_IMAGE,
+            cwd=cwd,
         )
-        job.env('HAIL_BUCKET', hail_bucket)
-        job.env('HAIL_BILLING_PROJECT', dataset)
-        job.env('DATASET_GCP_PROJECT', dataset_gcp_project)
-        job.env('OUTPUT', output_suffix)
-        if cwd:
-            job.command(f'cd {quote(cwd)}')
+    )
 
-        job.command(f'which {quote(script[0])} || chmod +x {quote(script[0])}')
+    # Publish the metadata to Pub/Sub. Wait for the result before running the batch.
+    publisher.publish(PUBSUB_TOPIC, metadata.encode('utf-8')).result()
 
-        # Finally, run the script.
-        escaped_script = ' '.join(quote(s) for s in script if s)
-        job.command(escaped_script)
+    user_name = email.split('@')[0]
+    batch_name = f'{user_name} {repo}:{commit}/{" ".join(script)}'
 
-        url = run_batch_job_and_print_url(batch, wait=params.get('wait', False))
+    dataset_gcp_project = server_config[dataset]['projectId']
+    batch = hb.Batch(
+        backend=backend, name=batch_name, requester_pays_project=dataset_gcp_project
+    )
 
-        return web.Response(text=f'{url}\n')
-    except KeyError as e:
-        logging.error(e)
-        raise web.HTTPBadRequest(reason=f'Missing request parameter: {e.args[0]}')
+    job = batch.new_job(name='driver')
+    job = prepare_git_job(
+        job=job,
+        dataset=dataset,
+        access_level=access_level,
+        output_suffix=output_suffix,
+        repo=repo,
+        commit=commit,
+        metadata_str=metadata,
+    )
+    job.env('HAIL_BUCKET', hail_bucket)
+    job.env('HAIL_BILLING_PROJECT', dataset)
+    job.env('DATASET_GCP_PROJECT', dataset_gcp_project)
+    job.env('OUTPUT', output_suffix)
+    if cwd:
+        job.command(f'cd {quote(cwd)}')
+
+    job.command(f'which {quote(script[0])} || chmod +x {quote(script[0])}')
+
+    # Finally, run the script.
+    escaped_script = ' '.join(quote(s) for s in script if s)
+    job.command(escaped_script)
+
+    url = run_batch_job_and_print_url(batch, wait=params.get('wait', False))
+
+    return web.Response(text=f'{url}\n')
 
 
 add_cromwell_routes(routes)
 
 
-def json_response(status_code: int, message: str) -> web.Response:
+def prepare_exception_json_response(status_code: int, message: str) -> web.Response:
+    """Prepare web.Response for """
     return web.Response(
         status=status_code,
         body=json.dumps({'message': message, 'success': False}).encode('utf-8'),
@@ -142,32 +153,47 @@ def json_response(status_code: int, message: str) -> web.Response:
     )
 
 
-def prepare_response_from_exception(request, ex):
-    logging.error('Request {} has failed with exception: {}'.format(request, repr(ex)))
+def prepare_response_from_exception(ex: Exception):
+    """Prepare json_response from exception"""
+    logging.error(f'Request failed with exception: {repr(ex)}')
 
     if isinstance(ex, web.HTTPException):
-        logging.error(ex)
-        return json_response(status_code=ex.status_code, message=ex.text)
+        return prepare_exception_json_response(
+            status_code=ex.status_code, message=ex.reason
+        )
     if isinstance(ex, KeyError):
         keys = ', '.join(ex.args)
-        return json_response(400, f'Missing request parameter: {keys}')
+        return prepare_exception_json_response(
+            400, f'Missing request parameter: {keys}'
+        )
+    if isinstance(ex, ValueError):
+        return prepare_exception_json_response(400, ', '.join(ex.args))
 
     if hasattr(ex, 'message'):
         m = ex.message
     else:
         m = str(ex)
-    return json_response(500, message=m)
+    return prepare_exception_json_response(500, message=m)
 
 
-async def error_middleware(app: web.Application, handler):
+async def error_middleware(_, handler):
+    """
+    Constructs middleware handler
+    First argument is app, but unused in this context
+    """
+
     async def middleware_handler(request):
+        """
+        Run handler and catch exceptions and response errors
+        """
         try:
             response = await handler(request)
             if isinstance(response, web.HTTPException):
-                return prepare_response_from_exception(request, response)
+                return prepare_response_from_exception(response)
             return response
+        # pylint: disable=broad-except
         except Exception as e:
-            return prepare_response_from_exception(request, e)
+            return prepare_response_from_exception(e)
 
     return middleware_handler
 
@@ -180,4 +206,4 @@ async def init_func():
 
 
 if __name__ == '__main__':
-    web.run_app(init_func())
+    web.run_app(init_func(), port=5050)

--- a/server/main.py
+++ b/server/main.py
@@ -27,17 +27,6 @@ from util import (
 
 routes = web.RouteTableDef()
 
-ANALYSIS_RUNNER_REQUIRED_PARAMS = [
-    'output',
-    'dataset',
-    'repo',
-    'accessLevel',
-    'commit',
-    'cwd',
-    'script',
-    'description',
-]
-
 
 # pylint: disable=too-many-statements
 @routes.post('/')
@@ -48,11 +37,6 @@ async def index(request):
     # When accessing a missing entry in the params dict, the resulting KeyError
     # exception gets translated to a Bad Request error in the try block below.
     params = await request.json()
-    missing_params = [
-        key for key in ANALYSIS_RUNNER_REQUIRED_PARAMS if key not in params
-    ]
-    if missing_params:
-        raise ValueError('Missing request parameter(s): ' + ', '.join(missing_params))
 
     server_config = get_server_config()
     output_suffix = validate_output_dir(params['output'])


### PR DESCRIPTION
Analysis runner is pretty vague on error messages from the client's point of view, and often requires someone to manually check the cloud logs. This PR adds a global exception handler to catch and return meaningful error messages. 

It also adds a _required parameters_ check up front, rather than relying on individual key errors. This change isn't that big, it's mostly un-indenting blocks of code and GH diff tool has not made it look pretty.

Now, the analysis-runner will return a response like the following:

Missing request parameter:
```json
{
    "message": "Missing request parameter(s): cwd, description",
    "success": false
}
```
Failed request to Hail batch:
```json
{
    "message": "unknown billing project fewgenomes__BAD",
    "success": false
}
```
Bad request JSON
```json
{
    "message": "Expecting property name enclosed in double quotes: line 13 column 1 (char 294)",
    "success": false
}
```
