### PR TITLE
Move metadata logging to after batch submit to catch url

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -120,7 +120,7 @@ async def index(request):
 
     url = run_batch_job_and_print_url(batch, wait=params.get('wait', False))
 
-    # Publish the metadata to Pub/Sub. Wait for the result before running the batch.
+    # Publish the metadata to Pub/Sub. Wait for the result before returning the url.
     metadata['batch_url'] = url
     publisher.publish(PUBSUB_TOPIC, json.dumps(metadata).encode('utf-8')).result()
 


### PR DESCRIPTION
Useful for linking the instance in the airtable to the actual run:
- New column has already been added to airtable, (eg: https://airtable.com/appOXBjVbfdF4ckHI/tblx9NarwtJwGqTPA/viwIomAHV49Stq5zr/rech6Q1x6ez02MTSy?blocks=hide)
- This works for sample-metadata too.
