### PR TITLE
Change AR server test to print Hail version

### DIFF
--- a/test/main.py
+++ b/test/main.py
@@ -3,4 +3,4 @@
 
 import hail as hl
 
-hl.init()
+print(hl.version())


### PR DESCRIPTION
We don't want to avoid deploying analysis-runner because hail query is misbehaving or misconfigured.
Eg: https://batch.hail.populationgenomics.org.au/batches/6408/jobs/1