### PR TITLE
Change the `seqr-standard` Hail service account

### DIFF
--- a/stack/Pulumi.seqr.yaml
+++ b/stack/Pulumi.seqr.yaml
@@ -5,7 +5,7 @@ config:
   datasets:depends_on: '["acute-care", "perth-neuro"]'
   datasets:enable_release: "false"
   datasets:hail_service_account_test: seqr-test-709@hail-295901.iam.gserviceaccount.com
-  datasets:hail_service_account_standard: seqr-standard-943@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: seqr-standard-758@hail-295901.iam.gserviceaccount.com
   datasets:hail_service_account_full: seqr-full-041@hail-295901.iam.gserviceaccount.com
   datasets:deployment_service_account_test: seqr-dev@seqr-308602.iam.gserviceaccount.com
   datasets:deployment_service_account_standard: seqr-prod@seqr-308602.iam.gserviceaccount.com


### PR DESCRIPTION
I had to replace the `seqr-standard` service account when trying to fix the issue with pending jobs (see for context https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch.20support/topic/Jobs.20stuck.20in.20.22Ready.22). Updating it in Pulumi config to reflect that change :)