### PR TITLE
Set `HAIL_QUERY_BACKEND=local` on driver image

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -4,7 +4,7 @@ ARG HAIL_VERSION
 
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
-ENV HAIL_QUERY_BACKEND service
+ENV HAIL_QUERY_BACKEND local
 
 RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x ./jq && cp jq /usr/bin && \


### PR DESCRIPTION
To make sure query scripts outside dataproc use the spark local backend, and not the incomplete service backend.

cc @KatalinaBobowik 