### PR TITLE
Bump cpg-utils to 2.1.2 to fix secret access

### DIFF
--- a/access_group_cache/Dockerfile
+++ b/access_group_cache/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y wget bzip2 && \
     wget -qO- https://api.anaconda.org/download/conda-forge/micromamba/0.8.2/linux-64/micromamba-0.8.2-he9b6cbd_0.tar.bz2 | tar -xvj -C /usr/local bin/micromamba && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX -c cpg -c conda-forge \
-    cpg-utils==2.1.1 aiohttp flask gunicorn && \
+    cpg-utils==2.1.2 aiohttp flask gunicorn && \
     rm -r /root/micromamba/pkgs
 
 COPY main.py ./


### PR DESCRIPTION
Relies on https://github.com/populationgenomics/cpg-utils/pull/8 being released.