### PR TITLE
Improve access_group_cache tolerance to failure

### DIFF
--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -15,7 +15,14 @@ ANALYSIS_RUNNER_PROJECT_ID = 'analysis-runner'
 app = Flask(__name__)
 
 
-async def _groups_lookup(access_token: str, group_name: str) -> Optional[str]:
+async def _get_group_parent(access_token: str, group_name: str) -> Optional[str]:
+    """
+    Get the group parent (group ID)
+    """
+    if group_name.endswith(".iam.gserviceaccount.com"):
+        # we know it's not a group, because it's a service account
+        return None
+
     async with aiohttp.ClientSession() as session:
         # https://cloud.google.com/identity/docs/reference/rest/v1/groups/lookup
         async with session.get(

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -19,7 +19,7 @@ async def _get_group_parent(access_token: str, group_name: str) -> Optional[str]
     """
     Get the group parent (group ID)
     """
-    if group_name.endswith(".iam.gserviceaccount.com"):
+    if group_name.endswith('.iam.gserviceaccount.com'):
         # we know it's not a group, because it's a service account
         return None
 
@@ -41,7 +41,9 @@ async def _get_group_parent(access_token: str, group_name: str) -> Optional[str]
             return json.loads(content)['name']
 
 
-async def _groups_memberships_list(access_token: str, group_parent: str) -> Tuple[List[str], List[str]]:
+async def _groups_memberships_list(
+    access_token: str, group_parent: str
+) -> Tuple[List[str], List[str]]:
     """Get a tuple of (group_emails, member_emails) in this group_parent"""
     members = []
     child_groups = []

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -52,6 +52,7 @@ async def _groups_memberships_list(
         page_token = None
         while True:
             # https://cloud.google.com/identity/docs/reference/rest/v1/groups/lookup
+            # use view=FULL so we get the membership 'type' (GROUP or other)
             async with session.get(
                 f'https://cloudidentity.googleapis.com/v1/{group_parent}/memberships?'
                 f'view=FULL&pageToken={page_token or ""}',
@@ -190,8 +191,8 @@ def index():
 
     for group, group_members in zip(groups, all_group_members):
         if isinstance(group_members, Exception):
-            logging.warning(
-                f'Skipping update for "{group}" due to exception {group_members}'
+            logging.error(
+                f'Skipping update for "{group}" due to exception: {group_members}'
             )
             continue
         secret_value = ','.join(group_members)

--- a/access_group_cache/main.py
+++ b/access_group_cache/main.py
@@ -118,7 +118,6 @@ async def _transitive_group_members(
                 # if any membership checked, fail the whole group
                 return membership_result
 
-            logging.info(f'Got child_groups and members: {membership_result}')
             child_groups, members = membership_result
 
             result.update(members)


### PR DESCRIPTION
There were some errors this morning (my testing indicates too-many-request exceptions) with group member resolution, and this script used exceptions to handle the "user is not a google group" case which caused unexpected downstream errors.

This PR does a few things:

- Allows group member resolution errors to bubble up, and will skip updating a group's secret.
- Catches only the 403 (auth) error during group_parent resolution to indicate a user is not a group
- Improves the group membership checks to identify whether a member is a group (and use that in the previous call)
- Adds an additional simple check for `.iam.gserviceaccount.com` to indicate user is not a group.
