### PR TITLE
Add skopeo to analysis-runner driver image

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -14,8 +14,19 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \
-        hail=$HAIL_VERSION cpg-utils analysis-runner sample-metadata=3.5.0 bokeh selenium phantomjs statsmodels \
-        r-base=4.1.1 r-essentials r-tidyverse r-argparser && \
+        hail=$HAIL_VERSION \
+        analysis-runner \
+        bokeh \
+        cpg-utils \
+        phantomjs \
+        r-argparser && \
+        r-base=4.1.1 \
+        r-essentials \
+        r-tidyverse \
+        sample-metadata=3.5.0 \
+        selenium \
+        skopeo \
+        statsmodels \
     rm -r /root/micromamba/pkgs && \
     # hailctl dataproc uses gcloud beta dataproc.
     gcloud -q components install beta

--- a/tokens/main.py
+++ b/tokens/main.py
@@ -10,10 +10,7 @@ from google.cloud import secretmanager
 
 # dataset -> list of git repos
 ALLOWED_REPOS = {
-    'acute-care': [
-        'sample-metadata',
-        'fewgenomes'
-    ],
+    'acute-care': ['sample-metadata', 'fewgenomes'],
     'ancestry': ['ancestry'],
     'fewgenomes': [
         'analysis-runner',


### PR DESCRIPTION
This is handy for copying Docker images into the Artifact Registry.

Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1641942379022300?thread_ts=1641940218.018900&cid=C018KFBCR1C