### PR TITLE
Bump sample-metadata version

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
         r-base=4.1.1 \
         r-essentials \
         r-tidyverse \
-        sample-metadata=4.1.0 \
+        sample-metadata=4.1.1 \
         selenium \
         skopeo \
         statsmodels && \


### PR DESCRIPTION
To fix `google-cloud-storage.download_as_string` error: https://github.com/populationgenomics/sample-metadata/pull/124