### PR TITLE
Small cromwell fixes

### DIFF
--- a/analysis_runner/cli_cromwell.py
+++ b/analysis_runner/cli_cromwell.py
@@ -105,9 +105,13 @@ def _add_cromwell_submit_args_to(parser):
     parser.add_argument(
         '-p',
         '--imports',
-        nargs='+',
         required=False,
-        help='A list of directories which are used to search for workflow imports',
+        action='append',
+        help=(
+            'A directory which is used to search for workflow imports. You can specify this argument multiple times.'
+            'Note: the directories are zipped from the cwd with `zip -r {directory1} {directory2}`.'
+            'Please raise an issue to change this behaviour',
+        ),
     )
     parser.add_argument(
         '--workflow-input-prefix',

--- a/examples/cromwell/README.md
+++ b/examples/cromwell/README.md
@@ -14,7 +14,7 @@ analysis-runner \
     --dataset fewgenomes \
     --output mfranklin-analysis-runner-test \
     --access-level test \
-    --description 'Hello, fewgenomes!'
+    --description 'Hello, fewgenomes!' \
     --workflow-input-prefix 'hello.' \
     --imports tools \
     hello.wdl \

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -37,7 +37,9 @@
     ],
     "kccg-genomics-med":
     [
-        "sample-metadata"
+        "sample-metadata",
+        "cromwell-kccg-mutect2-chip",
+        "analysis-runner"
     ],
     "mgrb":
     [


### PR DESCRIPTION
Having `--tools, nargs="+"` means that specifying `--tools toolsdir/ <myworkflow.wdl>` doesn't work. So remove that, and improve the docstring.