### PR TITLE
Use the cpg-hail pip package

### DIFF
--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -6,4 +6,4 @@ RUN apt update && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt update && apt install -y google-cloud-sdk && \
     apt clean && rm -rf /var/lib/apt/lists/* && \
-    pip3 install hail==0.2.73
+    pip3 install cpg-hail

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -27,6 +27,6 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
         skopeo \
         statsmodels && \
     rm -r /root/micromamba/pkgs && \
-    pip install cpg-hail=$HAIL_VERSION && \
+    pip3 install cpg-hail=$HAIL_VERSION && \
     # hailctl dataproc uses gcloud beta dataproc.
     gcloud -q components install beta

--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
     mkdir $MAMBA_ROOT_PREFIX && \
     micromamba install -y --prefix $MAMBA_ROOT_PREFIX \
         -c cpg -c bioconda -c conda-forge \
-        hail=$HAIL_VERSION \
         analysis-runner \
         bokeh \
         cpg-utils \
@@ -28,5 +27,6 @@ RUN apt-get update && apt-get install -y git wget bash bzip2 zip && \
         skopeo \
         statsmodels && \
     rm -r /root/micromamba/pkgs && \
+    pip install cpg-hail=$HAIL_VERSION && \
     # hailctl dataproc uses gcloud beta dataproc.
     gcloud -q components install beta


### PR DESCRIPTION
Adjusting Dockefiles to install the `cpg-hail` pip package instead of the conda package.

We can then further modify CI to build analysis-runner for pip as well