### PR TITLE
Allow view cpg_reference bucket for access group

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -601,7 +601,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         member=pulumi.Output.concat('group:', access_group.group_key.id),
     )
 
-    # Read access from the reference data.
+    # Read access to reference data.
     bucket_member(
         'access-group-reference-bucket-viewer',
         bucket=REFERENCE_BUCKET_NAME,

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -601,6 +601,14 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         member=pulumi.Output.concat('group:', access_group.group_key.id),
     )
 
+    # Read access from the reference data.
+    bucket_member(
+        'access-group-reference-bucket-viewer',
+        bucket=REFERENCE_BUCKET_NAME,
+        role=viewer_role_id,
+        member=pulumi.Output.concat('group:', access_group.group_key.id),
+    )
+
     # Allow the usage of requester-pays buckets.
     gcp.projects.IAMMember(
         f'access-group-serviceusage-consumer',


### PR DESCRIPTION
Since we are allowing all access group members pulling from the artefact registry, would it make sense to also allow reading from the `cpg_reference` bucket?

Another option would be to only allow listing (e.g. Storage Legacy Bucket Reader).