### PR TITLE
Switch back to query service backend by default

### DIFF
--- a/driver/Dockerfile
+++ b/driver/Dockerfile
@@ -13,7 +13,7 @@ FROM base as hail
 
 ARG HAIL_VERSION
 
-ENV HAIL_QUERY_BACKEND local
+ENV HAIL_QUERY_BACKEND service
 
 # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#23 about the mkdir.
 RUN mkdir /usr/share/man/man1 && \


### PR DESCRIPTION
Effectively reverts https://github.com/populationgenomics/analysis-runner/pull/283.

Also see https://centrepopgen.slack.com/archives/C018KFBCR1C/p1646799252310029.

Note: this is stacked on https://github.com/populationgenomics/analysis-runner/pull/344.