### PR TITLE
Determine Hail pip version by checking out the Hail repo at a given ref

### DIFF
--- a/.github/workflows/deploy_server.yaml
+++ b/.github/workflows/deploy_server.yaml
@@ -5,7 +5,7 @@ on:
       hail_sha:
         description: 'Hail GitHub commit SHA'
         required: true
-        default: 'HEAD'
+        default: "HEAD"
 
 jobs:
   deploy_server:

--- a/.github/workflows/deploy_server.yaml
+++ b/.github/workflows/deploy_server.yaml
@@ -1,16 +1,11 @@
-# This workflow is triggered after a new version of Hail has been built, with a
-# corresponding pip package. It leads to new driver and server Docker images being
-# built, followed by the deployment of the server.
-name: Deploy analysis-runner server after Hail update
+name: Deploy analysis-runner server
 on:
   workflow_dispatch:
     inputs:
-      hail_version:
-        description: 'Hail version (as uploaded to PyPI)'
-        required: true
       hail_sha:
         description: 'Hail GitHub commit SHA'
         required: true
+        default: 'HEAD'
 
 jobs:
   deploy_server:
@@ -20,12 +15,25 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      DRIVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}-${{ github.event.inputs.hail_sha }}
-      SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_version }}-${{ github.event.inputs.hail_sha }}
+      DRIVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:${{ github.sha }}-hail-${{ github.event.inputs.hail_sha }}
+      SERVER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-${{ github.event.inputs.hail_sha }}
 
     steps:
-    - name: "checkout repo"
-      uses: actions/checkout@v2
+    - name: "checkout analysis-runner repo"
+      uses: actions/checkout@v3
+
+    - name: "checkout Hail repo"
+      uses: actions/checkout@v3
+      with:
+        repository: "populationgenomics/hail"
+        ref: ${{ github.event.inputs.hail_sha }}
+        path: "hail"
+
+    - name: "Determine Hail pip version"
+      run: |
+        cd hail/hail
+        make python/hail/hail_pip_version
+        echo "HAIL_PIP_VERSION=$(cat python/hail/hail_pip_version)" >> $GITHUB_ENV
 
     - name: "gcloud setup"
       uses: google-github-actions/setup-gcloud@master
@@ -39,7 +47,7 @@ jobs:
 
     - name: "build driver image"
       run: |
-        docker build -f driver/Dockerfile.hail --build-arg HAIL_VERSION=${{ github.event.inputs.hail_version }} --tag $DRIVER_IMAGE driver
+        docker build -f driver/Dockerfile.hail --build-arg HAIL_PIP_VERSION=$HAIL_PIP_VERSION --tag $DRIVER_IMAGE driver
 
     - name: "push driver image"
       run: |

--- a/README.md
+++ b/README.md
@@ -160,19 +160,9 @@ pip install --editable .
 
 1. Add a Hail Batch service account for all supported datasets.
 1. [Copy the Hail tokens](tokens) to the Secret Manager.
-1. Deploy the [server](server) by invoking the [`hail_update` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/hail_update.yaml) manually, specifying the Hail package version.
+1. Deploy the [server](server) by invoking the [`deploy_server` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/deploy_server.yaml) manually.
 1. Deploy the [Airtable](airtable) publisher.
 1. Publish the [CLI tool and library](analysis_runner) to PyPI.
-
-Note that the [`hail_update` workflow](https://github.com/populationgenomics/analysis-runner/blob/main/.github/workflows/hail_update.yaml) gets invoked whenever a new Hail package is published to PyPI. You can test this manually as follows:
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/populationgenomics/analysis-runner/actions/workflows/6364059/dispatches \
-  -d '{"ref": "main", "inputs": {"hail_version": "0.2.84"}}'
-```
 
 The CLI tool is shipped as a pip package. To build a new version,
 we use [bump2version](https://pypi.org/project/bump2version/).

--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -1,7 +1,7 @@
 # This image adds Hail and some other Python-based stats libraries to the base image.
 FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.0
 
-ARG HAIL_VERSION
+ARG HAIL_PIP_VERSION
 
 ENV HAIL_QUERY_BACKEND service
 
@@ -13,7 +13,7 @@ RUN mkdir /usr/share/man/man1 && \
     pip3 install \
         analysis-runner \
         bokeh \
-        hail==$HAIL_VERSION \
+        hail==$HAIL_PIP_VERSION \
         cpg-utils \
         phantomjs \
         sample-metadata \


### PR DESCRIPTION
So we don't have to manually find and copy workflow parameters whenever re-releasing the analysis-runner for sample-metadata updates.