### PR TITLE
Quote dataproc --packages opt

### DIFF
--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -197,7 +197,7 @@ def _add_start_job(  # pylint: disable=too-many-arguments
             f'--secondary-worker-boot-disk-size={secondary_worker_boot_disk_size}'
         )
     if packages:
-        start_job_command.append(f'--packages={",".join(packages)}')
+        start_job_command.append(f'--packages=\'{",".join(packages)}\'')
     if init:
         start_job_command.append(f'--init={",".join(init)}')
     if vep:

--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -197,7 +197,7 @@ def _add_start_job(  # pylint: disable=too-many-arguments
             f'--secondary-worker-boot-disk-size={secondary_worker_boot_disk_size}'
         )
     if packages:
-        start_job_command.append(f'--packages=\'{",".join(packages)}\'')
+        start_job_command.append(f'--packages={quote(",".join(packages))}')
     if init:
         start_job_command.append(f'--init={",".join(init)}')
     if vep:


### PR DESCRIPTION
To support `>` and `[]` syntax in package specs; otherwise it silently starts a cluster without packages, like here: https://batch.hail.populationgenomics.org.au/batches/17781/jobs/1