### PR TITLE
google-github-actions/setup-gcloud@master --> google-github-actions/setup-gcloud@main

### DIFF
--- a/.github/workflows/deploy_server.yaml
+++ b/.github/workflows/deploy_server.yaml
@@ -38,7 +38,7 @@ jobs:
         echo "SERVER_IMAGE=australia-southeast1-docker.pkg.dev/analysis-runner/images/server:${{ github.sha }}-hail-$HAIL_SHA" >> $GITHUB_ENV
 
     - name: "gcloud setup"
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@main
       with:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}

--- a/.github/workflows/deploy_web_server.yaml
+++ b/.github/workflows/deploy_web_server.yaml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: "gcloud setup"
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@main
       with:
         project_id: analysis-runner
         service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}


### PR DESCRIPTION
> Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.