### PR TITLE
Add new seqr datasets

### DIFF
--- a/stack/Pulumi.brain-malf.yaml
+++ b/stack/Pulumi.brain-malf.yaml
@@ -1,0 +1,11 @@
+config:
+  datasets:archive_age: '90'
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: false
+  datasets:hail_service_account_full: brain-malf-full-315@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: brain-malf-standard-861@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: brain-malf-test-219@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: brain-malf
+  gcp:project: brain-malf
+  gcp:user_project_override: 'true'
+encryptionsalt: v1:SPQXlVggjxw=:v1:X1sTpViNuyK+Wcom:3GANI8gZOKtk0gG7BklsyHeNU5uVLw==

--- a/stack/Pulumi.leukodystrophies.yaml
+++ b/stack/Pulumi.leukodystrophies.yaml
@@ -1,0 +1,11 @@
+config:
+  datasets:archive_age: '90'
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: false
+  datasets:hail_service_account_full: leukodystrophies-full-536@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: leukodystrophies-standard-657@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: leukodystrophies-test-164@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: leukodystrophies
+  gcp:project: leukodystrophies
+  gcp:user_project_override: 'true'
+encryptionsalt: v1:SPQXlVggjxw=:v1:X1sTpViNuyK+Wcom:3GANI8gZOKtk0gG7BklsyHeNU5uVLw==

--- a/stack/Pulumi.mito-disease.yaml
+++ b/stack/Pulumi.mito-disease.yaml
@@ -1,0 +1,11 @@
+config:
+  datasets:archive_age: '90'
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: false
+  datasets:hail_service_account_full: mito-disease-full-261@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: mito-disease-standard-971@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: mito-disease-test-091@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: mito-disease
+  gcp:project: mito-disease
+  gcp:user_project_override: 'true'
+encryptionsalt: v1:SPQXlVggjxw=:v1:X1sTpViNuyK+Wcom:3GANI8gZOKtk0gG7BklsyHeNU5uVLw==

--- a/stack/Pulumi.ravenscroft-arch.yaml
+++ b/stack/Pulumi.ravenscroft-arch.yaml
@@ -1,0 +1,11 @@
+config:
+  datasets:archive_age: '90'
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: false
+  datasets:hail_service_account_full: ravenscroft-arch-full-263@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: ravenscroft-arch-standard-429@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: ravenscroft-arch-test-029@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: ravenscroft-arch
+  gcp:project: ravenscroft-arch
+  gcp:user_project_override: 'true'
+encryptionsalt: v1:SPQXlVggjxw=:v1:X1sTpViNuyK+Wcom:3GANI8gZOKtk0gG7BklsyHeNU5uVLw==

--- a/stack/Pulumi.seqr.yaml
+++ b/stack/Pulumi.seqr.yaml
@@ -2,7 +2,8 @@ config:
   datasets:archive_age: '30'
   datasets:customer_id: C010ys3gt
   datasets:depends_on: '["acute-care", "perth-neuro", "rdnow", "heartkids", "ravenscroft-rdstudy",
-    "ohmr3-mendelian", "ohmr4-epilepsy", "flinders-ophthal", "circa", "schr-neuro"]'
+    "ohmr3-mendelian", "ohmr4-epilepsy", "flinders-ophthal", "circa", "schr-neuro", "brain-malf",
+    "leukodystrophies", "mito-disease", "ravenscroft-arch"]'
   datasets:deployment_service_account_standard: seqr-prod@seqr-308602.iam.gserviceaccount.com
   datasets:deployment_service_account_test: seqr-dev@seqr-308602.iam.gserviceaccount.com
   datasets:enable_release: 'false'

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -92,5 +92,8 @@
     "sgs-somatic-mtn": [
         "sample-metadata",
         "sgs-somatic-mutation"
+    ],
+    "ravenscroft-arch": [
+        "sample-metadata"
     ]
 }

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -9,6 +9,9 @@
     "ancestry": [
         "ancestry"
     ],
+    "brain-malf": [
+        "sample-metadata"
+    ],
     "circa": [
         "sample-metadata"
     ],
@@ -39,7 +42,13 @@
         "cromwell-kccg-mutect2-chip",
         "analysis-runner"
     ],
+    "leukodystrophies": [
+        "sample-metadata"
+    ],
     "mgrb": [
+        "sample-metadata"
+    ],
+    "mito-disease": [
         "sample-metadata"
     ],
     "nagim": [
@@ -60,14 +69,24 @@
         "joint-calling",
         "gatk-sv"
     ],
+    "ravenscroft-arch": [
+        "sample-metadata"
+    ],
     "ravenscroft-rdstudy": [
         "sample-metadata"
     ],
     "rdnow": [],
+    "schr-neuro": [
+        "sample-metadata"
+    ],
     "seqr": [
         "hail-elasticsearch-pipelines",
         "sample-metadata",
         "production-pipelines"
+    ],
+    "sgs-somatic-mtn": [
+        "sample-metadata",
+        "sgs-somatic-mutation"
     ],
     "thousand-genomes": [
         "analysis-runner",
@@ -84,16 +103,6 @@
         "tob-wgs",
         "sv-workflows",
         "production-pipelines",
-        "sample-metadata"
-    ],
-    "schr-neuro": [
-        "sample-metadata"
-    ],
-    "sgs-somatic-mtn": [
-        "sample-metadata",
-        "sgs-somatic-mutation"
-    ],
-    "ravenscroft-arch": [
         "sample-metadata"
     ]
 }


### PR DESCRIPTION
The create-dataset script is more aggressively ordering results, so this PR cleans up two old entries too.
I've applied the dataset stacks (to generate the buckets), but not the seqr depends on relationships yet.