### PR TITLE
pin Jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         'google-cloud-pubsub==2.3.0',
         'google-cloud-secret-manager==2.2.0',
         'google-cloud-storage==1.25.0',
+        'Jinja2==3.0.3',
         'kubernetes',
         'pulumi-gcp',
         'requests',


### PR DESCRIPTION
Jinja2==3.1.0 is incompatible with Hail, waiting for new hail version which explicitly pins