### PR TITLE
Allow email access list overrides for web buckets

### DIFF
--- a/.github/workflows/deploy_web_server.yaml
+++ b/.github/workflows/deploy_web_server.yaml
@@ -34,8 +34,8 @@ jobs:
 
     - name: "deploy test-web"
       run: |
-        gcloud run deploy test-web --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=BUCKET_SUFFIX=test-web --image $DOCKER_IMAGE
+        gcloud run deploy test-web --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=BUCKET_SUFFIX=test-web,IAP_EXPECTED_AUDIENCE=/projects/370374240567/global/backendServices/3174620063505845348 --image $DOCKER_IMAGE
 
     - name: "deploy main-web"
       run: |
-        gcloud run deploy main-web --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=BUCKET_SUFFIX=main-web --image $DOCKER_IMAGE
+        gcloud run deploy main-web --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=BUCKET_SUFFIX=main-web,IAP_EXPECTED_AUDIENCE=/projects/370374240567/global/backendServices/1864569452412538381 --image $DOCKER_IMAGE

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -1,9 +1,20 @@
 FROM ubuntu:20.04
 
 RUN apt update && \
-    apt install -y --no-install-recommends apt-transport-https ca-certificates curl g++ git gnupg openjdk-8-jdk-headless libopenblas-base liblapack3 python3-pip zip && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt update && apt install -y google-cloud-sdk && \
-    apt clean && rm -rf /var/lib/apt/lists/* && \
-    pip3 install hail==0.2.91
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+        g++ \
+        liblapack3 \
+        libopenblas-base \
+        openjdk-8-jdk-headless \
+        python3-pip \
+        rsync && \
+    rm -r /var/lib/apt/lists/* && \
+    rm -r /var/cache/apt/* && \
+    # Install Hail from the CPG fork.
+    git clone https://github.com/populationgenomics/hail.git && \
+    cd hail/hail && \
+    # Install locally, avoiding the need for a pip package.
+    # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
+    make install DEPLOY_REMOTE=1 && \
+    cd ../.. && \
+    rm -rf hail

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -1,20 +1,9 @@
 FROM ubuntu:20.04
 
 RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y \
-        g++ \
-        liblapack3 \
-        libopenblas-base \
-        openjdk-8-jdk-headless \
-        python3-pip \
-        rsync && \
-    rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
-    # Install Hail from the CPG fork.
-    git clone https://github.com/populationgenomics/hail.git && \
-    cd hail/hail && \
-    # Install locally, avoiding the need for a pip package.
-    # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
-    make install DEPLOY_REMOTE=1 && \
-    cd ../.. && \
-    rm -rf hail
+    apt install -y --no-install-recommends apt-transport-https ca-certificates curl g++ git gnupg openjdk-8-jdk-headless libopenblas-base liblapack3 python3-pip zip && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt update && apt install -y google-cloud-sdk && \
+    apt clean && rm -rf /var/lib/apt/lists/* && \
+    pip3 install hail==0.2.91

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,8 +8,7 @@ RUN pip3 install  \
     gunicorn \
     google-api-python-client==2.10.0 \
     google-cloud-storage==1.38.0 \
-    google-cloud-secret-manager==2.2.0 \
-    google-auth==2.6.2
+    google-cloud-secret-manager==2.2.0
 
 COPY main.py ./
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,13 +3,15 @@ FROM python:3.10-slim
 ENV PYTHONUNBUFFERED True
 
 RUN pip3 install  \
-    cpg-utils==2.5.1 \
+    #cpg-utils==2.5.1 \
+    hail==0.2.91 \
+    google-auth==2.6.2 \
     cryptography \
     flask \
     gunicorn \
-    google-api-python-client==2.10.0 \
-    google-cloud-storage==1.38.0 \
-    google-cloud-secret-manager==2.2.0
+    google-api-python-client==2.42.0 \
+    google-cloud-storage==2.2.1 \
+    google-cloud-secret-manager==2.9.2
 
 COPY main.py ./
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,7 +8,8 @@ RUN pip3 install  \
     gunicorn \
     google-api-python-client==2.10.0 \
     google-cloud-storage==1.38.0 \
-    google-cloud-secret-manager==2.2.0
+    google-cloud-secret-manager==2.2.0 \
+    google-auth==2.6.2
 
 COPY main.py ./
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,17 +3,12 @@ FROM python:3.10-slim
 ENV PYTHONUNBUFFERED True
 
 RUN pip3 install  \
-    #cpg-utils==2.5.1 \
-    #hail==0.2.91 \
-    #google-auth==1.27.0 \
-    google-auth==2.6.2 \
-    cryptography \
+    cpg-utils==2.5.1 \
     flask \
     gunicorn \
-    google-api-python-client==2.42.0 \
-    #google-cloud-storage==1.25.0 \
-    google-cloud-storage==2.2.1 \
-    google-cloud-secret-manager==2.9.2
+    google-api-python-client==2.10.0 \
+    google-cloud-storage==1.38.0 \
+    google-cloud-secret-manager==2.2.0
 
 COPY main.py ./
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,12 +4,14 @@ ENV PYTHONUNBUFFERED True
 
 RUN pip3 install  \
     #cpg-utils==2.5.1 \
-    hail==0.2.91 \
+    #hail==0.2.91 \
+    #google-auth==1.27.0 \
     google-auth==2.6.2 \
     cryptography \
     flask \
     gunicorn \
     google-api-python-client==2.42.0 \
+    #google-cloud-storage==1.25.0 \
     google-cloud-storage==2.2.1 \
     google-cloud-secret-manager==2.9.2
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONUNBUFFERED True
 
 RUN pip3 install  \
     cpg-utils==2.5.1 \
+    cryptography \
     flask \
     gunicorn \
     google-api-python-client==2.10.0 \

--- a/web/main.py
+++ b/web/main.py
@@ -45,6 +45,8 @@ def handler(dataset=None, filename=None):
             audience=IAP_EXPECTED_AUDIENCE,
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
+        # Use allAuthenticatedUsers for the IAP configuration to make this
+        # work for arbitrary users.
         email = decoded_jwt['email']
     except Exception:  # pylint: disable=broad-except
         logger.exception('Failed to extract email from ID token')

--- a/web/main.py
+++ b/web/main.py
@@ -6,7 +6,7 @@ import mimetypes
 import os
 from flask import Flask, abort, request, Response
 
-# from cpg_utils.cloud import read_secret
+from cpg_utils.cloud import read_secret
 import google.cloud.storage
 import google.auth.transport.requests
 import google.oauth2.id_token
@@ -38,12 +38,6 @@ def handler(dataset=None, filename=None):
         logger.warning('Missing x-goog-iap-jwt-assertion header')
         abort(403)
 
-    # TODO: remove
-    from google.auth import jwt
-
-    def read_secret(x, y):
-        return ''
-
     try:
         decoded_jwt = google.oauth2.id_token.verify_token(
             iap_jwt,
@@ -51,10 +45,6 @@ def handler(dataset=None, filename=None):
             audience=IAP_EXPECTED_AUDIENCE,
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
-
-        logging.warning(f'x1 *** {decoded_jwt=}')
-        logging.warning(f'*** {jwt.decode(iap_jwt, verify=False)=}')
-
         email = decoded_jwt['email']
     except Exception:  # pylint: disable=broad-except
         logger.exception('Failed to extract email from ID token')

--- a/web/main.py
+++ b/web/main.py
@@ -5,7 +5,8 @@ import logging
 import mimetypes
 import os
 from flask import Flask, abort, request, Response
-from cpg_utils.cloud import read_secret
+
+# from cpg_utils.cloud import read_secret
 import google.cloud.storage
 import google.auth.transport.requests
 import google.oauth2.id_token
@@ -37,6 +38,12 @@ def handler(dataset=None, filename=None):
         logger.warning('Missing x-goog-iap-jwt-assertion header')
         abort(403)
 
+    # TODO: remove
+    from google.auth import jwt
+
+    def read_secret(x, y):
+        return ''
+
     try:
         decoded_jwt = google.oauth2.id_token.verify_token(
             iap_jwt,
@@ -45,10 +52,7 @@ def handler(dataset=None, filename=None):
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
 
-        # TODO: remove
-        from google.auth import jwt
-
-        logging.warning(f'*** {decoded_jwt=}')
+        logging.warning(f'x1 *** {decoded_jwt=}')
         logging.warning(f'*** {jwt.decode(iap_jwt, verify=False)=}')
 
         email = decoded_jwt['email']

--- a/web/main.py
+++ b/web/main.py
@@ -44,13 +44,14 @@ def handler(dataset=None, filename=None):
             audience=IAP_EXPECTED_AUDIENCE,
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
+        logging.info(f'{decoded_jwt=}')
         email = decoded_jwt['email']
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to extract email from ID token: {e}')
         abort(403)
 
     # Don't allow reading `.access` files.
-    if filename.endswith('/.access'):
+    if os.path.basename(filename) == '.access':
         abort(403)
 
     server_config = json.loads(read_secret(ANALYSIS_RUNNER_PROJECT_ID, 'server-config'))

--- a/web/main.py
+++ b/web/main.py
@@ -80,7 +80,7 @@ def handler(dataset=None, filename=None):
             if blob is None:
                 logger.warning(f'{email} is not a member of the {dataset} access group')
                 abort(403)
-            access_list = blob.download_as_string().splitlines()
+            access_list = blob.download_as_string().decode('utf-8').splitlines()
             if email not in access_list:
                 logger.warning(
                     f'{email} is not in {dataset} access group or {access_list_filename}'

--- a/web/main.py
+++ b/web/main.py
@@ -44,10 +44,16 @@ def handler(dataset=None, filename=None):
             audience=IAP_EXPECTED_AUDIENCE,
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
+
+        # TODO: remove
+        from google.auth import jwt
+
         logging.warning(f'*** {decoded_jwt=}')
+        logging.warning(f'*** {jwt.decode(iap_jwt, verify=False)=}')
+
         email = decoded_jwt['email']
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to extract email from ID token: {e}')
+    except Exception:  # pylint: disable=broad-except
+        logger.exception('Failed to extract email from ID token')
         abort(403)
 
     # Don't allow reading `.access` files.

--- a/web/main.py
+++ b/web/main.py
@@ -44,7 +44,7 @@ def handler(dataset=None, filename=None):
             audience=IAP_EXPECTED_AUDIENCE,
             certs_url='https://www.gstatic.com/iap/verify/public_key',
         )
-        logging.info(f'{decoded_jwt=}')
+        logging.warning(f'*** {decoded_jwt=}')
         email = decoded_jwt['email']
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to extract email from ID token: {e}')


### PR DESCRIPTION
If someone isn't in the generic access list for the web bucket, they can be listed in a `.access` file in the first subdirectory instead. This is helpful to give external collaborators access to particular files.

Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1648103614839679?thread_ts=1647580532.711369&cid=C018KFBCR1C