### PR TITLE
Revert "Revert "No need to set HAIL_JAR_URL anymore""

### DIFF
--- a/.github/workflows/deploy_server.yaml
+++ b/.github/workflows/deploy_server.yaml
@@ -65,7 +65,7 @@ jobs:
 
     - name: "deploy server-test"
       run: |
-        gcloud run deploy server-test --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE,HAIL_SHA=$HAIL_SHA --image $SERVER_IMAGE
+        gcloud run deploy server-test --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE --image $SERVER_IMAGE
 
     - name: "submit test batch"
       run: |
@@ -79,4 +79,4 @@ jobs:
 
     - name: "deploy server"
       run: |
-        gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE,HAIL_SHA=$HAIL_SHA --image $SERVER_IMAGE
+        gcloud run deploy server --region australia-southeast1 --no-allow-unauthenticated --platform managed --set-env-vars=DRIVER_IMAGE=$DRIVER_IMAGE --image $SERVER_IMAGE

--- a/server/main.py
+++ b/server/main.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import logging
-import os
 from shlex import quote
 
 import hailtop.batch as hb
@@ -37,10 +36,6 @@ if USE_GCP_LOGGING:
     client = google.cloud.logging.Client()
     client.get_default_handler()
     client.setup_logging()
-
-HAIL_SHA = os.getenv('HAIL_SHA')
-assert HAIL_SHA
-HAIL_JAR_URL = f'gs://hail-query-daaf463550/jars/{HAIL_SHA}.jar'
 
 routes = web.RouteTableDef()
 
@@ -145,8 +140,6 @@ async def index(request):
     job.env('CPG_OUTPUT_PREFIX', output_prefix)
     job.env('HAIL_BILLING_PROJECT', dataset)
     job.env('HAIL_BUCKET', hail_bucket)
-    job.env('HAIL_JAR_URL', HAIL_JAR_URL)
-    job.env('HAIL_SHA', HAIL_SHA)
 
     if environment_variables:
         if not isinstance(environment_variables, dict):


### PR DESCRIPTION
Try this again, now that Hail 0.2.93 has been deployed.

The unrelated linter issues get fixed in https://github.com/populationgenomics/analysis-runner/pull/382.