### PR TITLE
Pin to older cryptography version

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,13 +3,13 @@ FROM python:3.10-slim
 ENV PYTHONUNBUFFERED True
 
 RUN pip3 install  \
-    cpg-utils==2.5.1 \
-    cryptography \
-    flask \
-    gunicorn \
-    google-api-python-client==2.10.0 \
-    google-cloud-storage==1.38.0 \
-    google-cloud-secret-manager==2.2.0
+    cpg-utils==4.3.6 \
+    cryptography==3.3.2 \
+    flask==2.1.2 \
+    gunicorn==20.1.0 \
+    google-api-python-client==2.51.0 \
+    google-cloud-storage==2.4.0 \
+    google-cloud-secret-manager==2.11.1
 
 COPY main.py ./
 


### PR DESCRIPTION
google-auth relies on cryptography.utils.int_from_bytes, which was deprecated in 3.4.0.