### PR TITLE
Install pyarrow

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -34,6 +34,7 @@ RUN apt update && \
         sample-metadata \
         selenium \
         statsmodels && \
+        pyarrow && \
     # Install Hail from the CPG fork.
     git clone https://github.com/populationgenomics/hail.git && \
     cd hail && \


### PR DESCRIPTION
Pyarrow is required for hail's to_parquet function - so driver is well placed to install it IMO.