### PR TITLE
Add GTEx related datasets

### DIFF
--- a/stack/Pulumi.gtex.yaml
+++ b/stack/Pulumi.gtex.yaml
@@ -1,0 +1,11 @@
+encryptionsalt: v1:wfzYjy3Nmhg=:v1:RCKrpUjpR5YxZ996:MyYAO0ogR3v2Pp/bf1q7cO9d865ECw==
+config:
+  datasets:archive_age: "90"
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: "false"
+  datasets:hail_service_account_full: gtex-full-991@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: gtex-standard-245@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: gtex-test-234@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: gtex-461745
+  gcp:project: gtex-461745
+  gcp:user_project_override: "true"

--- a/stack/Pulumi.transcript-adapt.yaml
+++ b/stack/Pulumi.transcript-adapt.yaml
@@ -1,0 +1,12 @@
+encryptionsalt: v1:UrcbDOa2Uak=:v1:ETPDOGDmERIcBUbc:BTqyGZzzQ7PSen/ETT65oE/MA8VGvw==
+config:
+  datasets:archive_age: "90"
+  datasets:customer_id: C010ys3gt
+  datasets:depends_on: '["gtex"]'
+  datasets:enable_release: "false"
+  datasets:hail_service_account_full: transcript-adapt-full-328@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: transcript-adapt-standard-314@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: transcript-adapt-test-535@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: transcript-adapt
+  gcp:project: transcript-adapt
+  gcp:user_project_override: "true"

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -42,6 +42,9 @@
     "flinders-ophthal": [
         "sample-metadata"
     ],
+    "gtex": [
+        "sample-metadata"
+    ],
     "heartkids": [
         "sample-metadata"
     ],
@@ -131,6 +134,9 @@
         "tob-wgs",
         "sv-workflows",
         "production-pipelines",
+        "sample-metadata"
+    ],
+    "transcript-adapt": [
         "sample-metadata"
     ],
     "validation": [


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1657596133676809

Note that `transcript-adapt` depends on `gtex`, as the latter is a generic resource that we expect to be shared across multiple efforts.