### PR TITLE
Fix TZ=Australia backend

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -4,7 +4,7 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.2
 ARG HAIL_SHA
 
 ENV HAIL_QUERY_BACKEND service
-ENV TZ="Australia"
+ENV TZ Australia
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive apt install -y \

--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -3,8 +3,8 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.2
 
 ARG HAIL_SHA
 
-ENV HAIL_QUERY_BACKEND service \
-    TZ=Australia
+ENV HAIL_QUERY_BACKEND service
+ENV TZ=Australia
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive apt install -y \

--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -4,7 +4,7 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.2
 ARG HAIL_SHA
 
 ENV HAIL_QUERY_BACKEND service
-ENV TZ=Australia
+ENV TZ="Australia"
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive apt install -y \


### PR DESCRIPTION
Hail's backend determination requires a full String match to service, batch, local, etc. 
This line caused the backend env variable to be `service   TZ="Australia"` so a full match was not possible

context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1659395182183599
