### PR TITLE
Build the Dataproc image from our Hail fork

### DIFF
--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && \
         zip && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
-    apt update && apt install -y google-cloud-sdk && \
-    apt clean && rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    apt-get install -y google-cloud-sdk && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     git clone https://github.com/populationgenomics/hail.git && \
     cd hail/hail && \
     make install DEPLOY_REMOTE=1 && \

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -1,9 +1,26 @@
 FROM ubuntu:20.04
 
-RUN apt update && \
-    apt install -y --no-install-recommends apt-transport-https ca-certificates curl g++ git gnupg openjdk-8-jdk-headless libopenblas-base liblapack3 python3-pip zip && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        g++ \
+        git \
+        gnupg \
+        liblapack3 \
+        libopenblas-base \
+        make \
+        openjdk-8-jdk-headless \
+        python3-pip \
+        rsync \
+        zip && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt update && apt install -y google-cloud-sdk && \
     apt clean && rm -rf /var/lib/apt/lists/* && \
-    pip3 install hail==0.2.95
+    git clone https://github.com/populationgenomics/hail.git && \
+    cd hail/hail && \
+    make install DEPLOY_REMOTE=1 && \
+    cd ../.. && \
+    rm -rf hail

--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -3,10 +3,14 @@
 This Docker image is used to launch Dataproc clusters when using the
 [dataproc helper module](../analysis_runner/dataproc.py).
 
+Note that our [Hail fork](https://github.com/populationgenomics/hail) at `HEAD` is used to build the image.
+
+When you change the `HAIL_VERSION` below, make sure to update [dataproc.py](../analysis_runner/dataproc.py) accordingly and release a new `analysis-runner` library package.
+
 To build, run:
 
 ```sh
 gcloud config set project analysis-runner
-HAIL_VERSION=0.2.95
+HAIL_VERSION=0.2.97
 gcloud builds submit --timeout=1h --tag=australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc:hail-$HAIL_VERSION .
 ```


### PR DESCRIPTION
That allows us to implement fixes (e.g. to `hailctl`) and deploy / test them before they're released upstream.