### PR TITLE
Install gcsfs in driver image

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -29,6 +29,7 @@ RUN apt update && \
         cloudpathlib[all] \
         cpg-pipes \
         cpg-utils \
+        gcsfs \
         phantomjs \
         pyarrow \
         sample-metadata \


### PR DESCRIPTION
Allows `pandas` to read Parquet directly from GCS