### PR TITLE
Fix passing Dataproc region

### DIFF
--- a/analysis_runner/dataproc.py
+++ b/analysis_runner/dataproc.py
@@ -282,7 +282,7 @@ def _add_submit_job(
 
     main_job.command(
         f'hailctl dataproc submit '
-        f'--region={region}'
+        f'--region={region} '
         + (f'--pyfiles {",".join(pyfiles)} ' if pyfiles else '')
         + f'{cluster_id} {script} '
     )


### PR DESCRIPTION
Apparently this is now a required argument for `hailctl dataproc stop`: https://batch.hail.populationgenomics.org.au/batches/142988/jobs/3