### PR TITLE
Add shared project (for data egress protection)

### DIFF
--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -660,7 +660,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     if enable_shared_project:
         if not release_bucket:
             raise ValueError(
-                'Requested shared project, but no bucket is available to shared from'
+                'Requested shared project, but no bucket is available to share'
             )
 
         shared_buckets = {'release': release_bucket}
@@ -685,7 +685,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             opts=pulumi.resource.ResourceOptions(depends_on=[cloudbilling]),
         )
 
-        # create project to cover shared
+        # create project to cover costs of shared access, like network egress
         shared_project = gcp.organizations.Project(
             f'{dataset}-collaborator-shared-project',
             org_id=organization.org_id,
@@ -748,7 +748,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             project=shared_project.name,
         )
 
-        # Allow the usage of requester-pays buckets.
+        # Allow the usage of Requester Pays buckets.
         gcp.projects.IAMMember(
             f'shared-project-serviceusage-consumer',
             role='roles/serviceusage.serviceUsageConsumer',

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -77,6 +77,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     lister_role_id = org_role_id('StorageLister')
     viewer_creator_role_id = org_role_id('StorageViewerAndCreator')
     viewer_role_id = org_role_id('StorageObjectAndBucketViewer')
+    dataproc_worker_role_id = org_role_id('DataprocWorkerWithoutStorageAccess')
 
     # The Cloud Resource Manager API is required for the Cloud Identity API.
     cloudresourcemanager = gcp.projects.Service(
@@ -1028,7 +1029,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
 
         gcp.projects.IAMMember(
             f'dataproc-service-account-{access_level}-dataproc-worker',
-            role='roles/dataproc.worker',
+            role=dataproc_worker_role_id,
             member=pulumi.Output.concat('serviceAccount:', service_account),
         )
 
@@ -1044,7 +1045,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         # Worker permissions are necessary to submit jobs.
         gcp.projects.IAMMember(
             f'hail-service-account-{access_level}-dataproc-worker',
-            role='roles/dataproc.worker',
+            role=dataproc_worker_role_id,
             member=pulumi.Output.concat('serviceAccount:', service_account),
         )
 

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -562,6 +562,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         'project-buckets-lister',
         role=lister_role_id,
         member=pulumi.Output.concat('group:', access_group.group_key.id),
+        project=project_id,
     )
 
     # Grant visibility to Dataproc utilization metrics etc.
@@ -569,6 +570,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         'project-monitoring-viewer',
         role='roles/monitoring.viewer',
         member=pulumi.Output.concat('group:', access_group.group_key.id),
+        project=project_id,
     )
 
     bucket_member(
@@ -712,6 +714,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         f'access-group-serviceusage-consumer',
         role='roles/serviceusage.serviceUsageConsumer',
         member=pulumi.Output.concat('group:', access_group.group_key.id),
+        project=project_id,
     )
 
     # Allow the access group cache to list memberships.
@@ -799,6 +802,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             f'{access_level}-serviceusage-consumer',
             role='roles/serviceusage.serviceUsageConsumer',
             member=pulumi.Output.concat('group:', group.group_key.id),
+            project=project_id,
         )
 
     # The bucket used for Hail Batch pipelines, e.g. for passing input / output
@@ -1031,6 +1035,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             f'dataproc-service-account-{access_level}-dataproc-worker',
             role=dataproc_worker_role_id,
             member=pulumi.Output.concat('serviceAccount:', service_account),
+            project=project_id,
         )
 
     for access_level, service_account in service_accounts['hail']:
@@ -1040,6 +1045,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             f'hail-service-account-{access_level}-dataproc-admin',
             role='roles/dataproc.admin',
             member=pulumi.Output.concat('serviceAccount:', service_account),
+            project=project_id,
         )
 
         # Worker permissions are necessary to submit jobs.
@@ -1047,6 +1053,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             f'hail-service-account-{access_level}-dataproc-worker',
             role=dataproc_worker_role_id,
             member=pulumi.Output.concat('serviceAccount:', service_account),
+            project=project_id,
         )
 
         # Add Hail service accounts to Cromwell access group.
@@ -1088,6 +1095,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
             f'cromwell-service-account-{access_level}-workflows-runner',
             role='roles/lifesciences.workflowsRunner',
             member=pulumi.Output.concat('serviceAccount:', service_account),
+            project=project_id,
         )
 
         # Store the service account key as a secret that's readable by the

--- a/stack/requirements.txt
+++ b/stack/requirements.txt
@@ -1,5 +1,5 @@
-pulumi>=2.0.0,<3.0.0
-pulumi-gcp>=4.0.0,<5.0.0
+pulumi==3.38.0
+pulumi-gcp==6.35.0
 google-cloud-billing-budgets==1.5.1
 requests==2.27.1
 PyYAML==5.4.1


### PR DESCRIPTION
Configurable on the dataset's config:

```yaml
  datasets:enable_egress_project: "true"
  datasets:egress_budget: 123
```

- Creates a new project with format `cpg-{dataset}-egress` to avoid any name clashes
- Creates a budget for that project
- Creates a service account in that new project
- Allows that service-account to access requester-pays buckets
- Allow that service-account to access the _release_ bucket on the parent project.