### PR TITLE
Adds "reference" dataset

### DIFF
--- a/stack/Pulumi.reference.yaml
+++ b/stack/Pulumi.reference.yaml
@@ -1,0 +1,10 @@
+config:
+  datasets:archive_age: '90'
+  datasets:customer_id: C010ys3gt
+  datasets:enable_release: false
+  datasets:hail_service_account_full: reference-full-612@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_standard: reference-standard-424@hail-295901.iam.gserviceaccount.com
+  datasets:hail_service_account_test: reference-test-306@hail-295901.iam.gserviceaccount.com
+  gcp:billing_project: reference-762817
+  gcp:project: reference-762817
+  gcp:user_project_override: 'true'

--- a/stack/Pulumi.reference.yaml
+++ b/stack/Pulumi.reference.yaml
@@ -1,10 +1,11 @@
+encryptionsalt: v1:DunweHhmzCI=:v1:tygBZgKrbXA/zgii:KKS16pfoL346CorH2EwN4I7g+siePA==
 config:
-  datasets:archive_age: '90'
+  datasets:archive_age: "90"
   datasets:customer_id: C010ys3gt
-  datasets:enable_release: false
+  datasets:enable_release: "false"
   datasets:hail_service_account_full: reference-full-612@hail-295901.iam.gserviceaccount.com
   datasets:hail_service_account_standard: reference-standard-424@hail-295901.iam.gserviceaccount.com
   datasets:hail_service_account_test: reference-test-306@hail-295901.iam.gserviceaccount.com
   gcp:billing_project: reference-762817
   gcp:project: reference-762817
-  gcp:user_project_override: 'true'
+  gcp:user_project_override: "true"

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -804,6 +804,16 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         member=pulumi.Output.concat('group:', access_group.group_key.id),
     )
 
+    # DEPRECATED on 30 AUG 2022. Remove after all pointers to cpg-reference removed.
+    # Read access to reference data.
+    bucket_member(
+        'access-group-reference-bucket-viewer',
+        bucket=REFERENCE_BUCKET_NAME,
+        role=viewer_role_id,
+        member=pulumi.Output.concat('group:', access_group.group_key.id),
+    )
+    # END DEPRECATED
+
     # Read access to Hail wheels.
     bucket_member(
         'access-group-hail-wheels-viewer',
@@ -883,6 +893,16 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
                 role='roles/artifactregistry.writer',
                 member=pulumi.Output.concat('group:', group.group_key.id),
             )
+
+        # DEPRECATED on 30 AUG 2022. Remove after all pointers to cpg-reference removed.
+        # Read access to reference data.
+        bucket_member(
+            f'{access_level}-reference-bucket-viewer',
+            bucket=REFERENCE_BUCKET_NAME,
+            role=viewer_role_id,
+            member=pulumi.Output.concat('group:', group.group_key.id),
+        )
+        # END DEPRECATED
 
         # Read access to Hail wheels.
         bucket_member(

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -35,6 +35,7 @@ ACCESS_GROUP_CACHE_SERVICE_ACCOUNT = (
     'access-group-cache@analysis-runner.iam.gserviceaccount.com'
 )
 REFERENCE_DATASET = 'reference'
+REFERENCE_BUCKET_NAME = 'cpg-reference'
 ANALYSIS_RUNNER_CONFIG_BUCKET_NAME = 'cpg-config'
 HAIL_WHEEL_BUCKET_NAME = 'cpg-hail-ci'
 NOTEBOOKS_PROJECT = 'notebooks-314505'

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -74,7 +74,8 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     dependency_stacks = {}
     # all datasets implicitly depend on the "reference" dataset:
     for dependency in ['reference'] + (config.get_object('depends_on') or []):
-        dependency_stacks[dependency] = pulumi.StackReference(dependency)
+        if dependency != dataset:
+            dependency_stacks[dependency] = pulumi.StackReference(dependency)
 
     def org_role_id(id_suffix: str) -> str:
         return f'{organization.id}/roles/{id_suffix}'

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -72,7 +72,8 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     project_id = gcp.organizations.get_project().project_id
 
     dependency_stacks = {}
-    for dependency in config.get_object('depends_on') or ():
+    # all datasets implicitly depend on the "reference" dataset:
+    for dependency in ['reference'] + (config.get_object('depends_on') or []):
         dependency_stacks[dependency] = pulumi.StackReference(dependency)
 
     def org_role_id(id_suffix: str) -> str:

--- a/stack/new_stack.py
+++ b/stack/new_stack.py
@@ -425,9 +425,11 @@ def create_stack(
 
     branch_name = f'add-{dataset}-stack'
     if should_commit:
-        current_branch = subprocess.check_output(
-            ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
-        ).decode()
+        current_branch = (
+            subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+            .decode()
+            .strip()
+        )
         if current_branch != 'main':
             should_continue = click.confirm(
                 f'Expected branch to be "main", got "{current_branch}". '

--- a/tokens/repository-map.json
+++ b/tokens/repository-map.json
@@ -128,6 +128,9 @@
     "rdnow": [
         "automated-interpretation-pipeline"
     ],
+    "reference": [
+        "sample-metadata"
+    ],
     "schr-neuro": [
         "automated-interpretation-pipeline",
         "sample-metadata"


### PR DESCRIPTION
Create `reference` dataset. Set implicit dependency of all datasets to `reference`.

Check list to do after approving:

- [x] Rerun `new_stack.py` with `--deploy-stack`.
- [ ] Run `update_all_stacks.py` to set dependencies of all other datasets to `reference`.
- [ ] Copy `gs://cpg-reference` contents into `gs://cpg-reference-main`.
- [ ] Create a PR in cpg-utils to modify the `workflow/reference_prefix` in the config to point to `cpg-reference-main`.
- [ ] Search other repos for the code that points to `cpg-reference` explicitly and modify to either use the `reference_path()` function or `get_config()['workflow']['reference_prefix']`.
- [ ] Make sure that no batches are running that might use `gs://cpg-reference`.
- [ ] Give a heads up in team-data and wipe `gs://cpg-reference`.
- [ ] Remove the deprecated pulumi statements that set permissions to `gs://cpg-reference` and rerun `update_all_stack.py`