### PR TITLE
improves flexibility of MT copying script

### DIFF
--- a/scripts/subset_matrix_table.py
+++ b/scripts/subset_matrix_table.py
@@ -220,7 +220,7 @@ if __name__ == '__main__':
     main(
         mt_path=args.i,
         output_root=args.out,
-        samples=set(args.s),
+        samples=set(args.s) if args.s else None,
         out_format=args.format,
         locus=locus_interval,
         keep_hom_ref=args.keep_ref,

--- a/scripts/subset_matrix_table.py
+++ b/scripts/subset_matrix_table.py
@@ -167,6 +167,10 @@ def clean_locus(contig: str, pos: str) -> hl.IntervalExpression | None:
             if int(end) > hl.get_reference('GRCh38').lengths[contig]:
                 end = hl.get_reference('GRCh38').lengths[contig]
 
+        # final check that numeric coordinates are ordered
+        if start != 'start' and end != 'end':
+            assert int(start) < int(end)
+
     else:
         assert int(
             pos

--- a/scripts/subset_matrix_table.py
+++ b/scripts/subset_matrix_table.py
@@ -157,9 +157,9 @@ def clean_locus(contig: str, pos: str) -> hl.IntervalExpression | None:
         assert pos.count('-') == 1, f'Positions must be one value, or a range between two values: {pos}'
         start, end = pos.split('-')
         if start != 'start':
-            assert int(start) >= 0, f'start value couldn\'t be converted to an int: {start}'
+            assert int(start) >= 0, f'start value could not be converted to an int: {start}'
         if end != 'end':
-            assert int(end), f'end value couldn\'t be converted to an int: {end}'
+            assert int(end), f'end value could not be converted to an int: {end}'
 
     else:
         assert int(pos), f'if only one position is specified, it must be numerical: {pos}'

--- a/scripts/subset_matrix_table.py
+++ b/scripts/subset_matrix_table.py
@@ -162,6 +162,7 @@ def clean_locus(contig: str, pos: str) -> hl.IntervalExpression | None:
             assert int(end), f'end value couldn\'t be converted to an int: {end}'
 
     else:
+        assert int(pos), f'if only one position is specified, it must be numerical: {pos}'
         start = int(pos)
         end = start + 1
 


### PR DESCRIPTION
Initial version didn't allow for 'no samples', i.e. retain all original samples in the copied data
Initial version didn't accept the hail syntax for `chr1:start-end` (or mixing `start-12345`, or `7890-end`)
alters the input validation to take these into account