### PR TITLE
Install python3-cffi to work around version mismatch when installing limix

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -7,21 +7,25 @@ ENV HAIL_QUERY_BACKEND service
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        curl \
         g++ \
+        gcc \
         libfontconfig \
         liblapack3 \
         libopenblas-base \
         openjdk-8-jdk-headless \
-        python3-pip \
         rsync \
-        software-properties-common \
-        gcc \
-        build-essential \
-        curl && \
+        software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get install -y \
+        python3-apt \
+        python3-cffi \
+        python3.10 \
+        python3.10-dev \
+        python3.10-distutils && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
-    add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get install -y --no-install-recommends python3.10 python3.10-distutils python3-apt python3.10-dev  && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
     rm $(which python3) && ln $(which python3.10) /usr/bin/python3 && \
     pip --no-cache-dir install \


### PR DESCRIPTION
Context: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1664172575232459?thread_ts=1664168914.639029&cid=C018KFBCR1C