### PR TITLE
Driver: move installing `hail` from source before `analysis-runner`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,8 @@
 
 disable=f-string-without-interpolation,logging-fstring-interpolation,inherit-non-class,
             too-few-public-methods,fixme,line-too-long,too-many-statements,
-            too-many-lines,too-many-instance-attributes,R0801,c-extension-no-member,no-member,W3101
+            too-many-lines,too-many-instance-attributes,R0801,c-extension-no-member,
+            no-member,W3101,import-error,no-name-in-module
 
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables

--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -38,7 +38,7 @@ RUN apt-get update && \
     # Install Hail from the CPG fork.
     git clone https://github.com/populationgenomics/hail.git && \
     cd hail && \
-    git checkout main && \
+    git checkout $HAIL_SHA && \
     cd hail && \
     # Install locally, avoiding the need for a pip package.
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.

--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -28,16 +28,6 @@ RUN apt-get update && \
     rm -r /var/cache/apt/* && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
     rm $(which python3) && ln $(which python3.10) /usr/bin/python3 && \
-    pip --no-cache-dir install \
-        analysis-runner \
-        bokeh \
-        cloudpathlib[all] \
-        cpg-utils \
-        gcsfs \
-        pyarrow \
-        sample-metadata \
-        selenium==3.8.0 \
-        statsmodels && \
     # Install phantomjs with a workaround for libssl_conf.so:
     # https://github.com/bazelbuild/rules_closure/issues/351#issuecomment-854628326
     cd /opt && \
@@ -48,10 +38,20 @@ RUN apt-get update && \
     # Install Hail from the CPG fork.
     git clone https://github.com/populationgenomics/hail.git && \
     cd hail && \
-    git checkout $HAIL_SHA && \
+    git checkout main && \
     cd hail && \
     # Install locally, avoiding the need for a pip package.
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
     make install DEPLOY_REMOTE=1 && \
     cd ../.. && \
-    rm -rf hail
+    rm -rf hail && \
+    pip --no-cache-dir install \
+        analysis-runner \
+        cpg-utils \
+        sample-metadata \
+        bokeh \
+        cloudpathlib[all] \
+        gcsfs \
+        pyarrow \
+        selenium>=3.8.0 \
+        statsmodels

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,14 +2,8 @@ FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED True
 
-RUN pip3 install  \
-    cpg-utils==4.3.6 \
-    cryptography==3.3.2 \
-    flask==2.1.2 \
-    gunicorn==20.1.0 \
-    google-api-python-client==2.51.0 \
-    google-cloud-storage==2.4.0 \
-    google-cloud-secret-manager==2.11.1
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
 
 COPY main.py ./
 

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,0 +1,7 @@
+cpg-utils==4.3.6
+cryptography==3.3.2
+flask==2.1.2
+gunicorn==20.1.0
+google-api-python-client==2.51.0
+google-cloud-storage==2.4.0
+google-cloud-secret-manager==2.11.1


### PR DESCRIPTION
Thanks @illusional for the idea. It does seem to help with `pip` pulling older `hail` versions. 

However, building hail from source doesn't work for yet another reason:

```
...
#5 211.0 Starting a Gradle Daemon (subsequent builds will be faster)
#5 305.9 > Task :compileJava NO-SOURCE
#5 335.9 > Task :compileScala
#5 652.5 > Task :compileScala FAILED
#5 653.8
#5 653.8 FAILURE: Build failed with an exception.
#5 653.8
#5 653.8 * What went wrong:
#5 653.8 Execution failed for task ':compileScala'.
#5 653.8 > Failed to run Gradle Worker Daemon
#5 653.8    > Process 'Gradle Worker Daemon 1' finished with non-zero exit value 137
...
```