### PR TITLE
Initial environment support for single-stack modified format

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,7 +17,7 @@
 disable=f-string-without-interpolation,logging-fstring-interpolation,inherit-non-class,
             too-few-public-methods,fixme,line-too-long,too-many-statements,
             too-many-lines,too-many-instance-attributes,R0801,c-extension-no-member,
-            no-member,W3101,import-error,no-name-in-module
+            no-member,import-error,no-name-in-module
 
 
 # Overriding variable name patterns to allow short 1- or 2-letter variables

--- a/analysis_runner/cli_analysisrunner.py
+++ b/analysis_runner/cli_analysisrunner.py
@@ -224,6 +224,7 @@ def run_analysis_runner(  # pylint: disable=too-many-arguments
             'config': _config,
         },
         headers={'Authorization': f'Bearer {_token}'},
+        timeout=60,
     )
     try:
         response.raise_for_status()

--- a/analysis_runner/cli_cromwell.py
+++ b/analysis_runner/cli_cromwell.py
@@ -250,6 +250,7 @@ curl --location --request POST \\
         headers={
             'Authorization': f'Bearer {get_google_identity_token(server_endpoint)}'
         },
+        timeout=60,
     )
     try:
         response.raise_for_status()
@@ -271,6 +272,7 @@ def _check_cromwell_status(workflow_id, json_output: Optional[str], *args, **kwa
         headers={
             'Authorization': f'Bearer {get_google_identity_token(SERVER_ENDPOINT)}'
         },
+        timeout=60,
     )
     response.raise_for_status()
     d = response.json()

--- a/analysis_runner/cromwell.py
+++ b/analysis_runner/cromwell.py
@@ -373,7 +373,9 @@ def watch_workflow(
         )
         try:
             token = _get_cromwell_oauth_token()
-            r = requests.get(url, headers={'Authorization': f'Bearer {token}'})
+            r = requests.get(
+                url, headers={'Authorization': f'Bearer {token}'}, timeout=60
+            )
             if not r.ok:
                 _remaining_exceptions -= 1
                 logger.warning(
@@ -392,7 +394,9 @@ def watch_workflow(
                     f'/v1/{workflow_id}/outputs'
                 )
                 r_outputs = requests.get(
-                    outputs_url, headers={'Authorization': f'Bearer {token}'}
+                    outputs_url,
+                    headers={'Authorization': f'Bearer {token}'},
+                    timeout=60,
                 )
                 if not r_outputs.ok:
                     logger.warning(

--- a/analysis_runner/util.py
+++ b/analysis_runner/util.py
@@ -118,7 +118,7 @@ def _perform_version_check():
         'analysis-runner/main/analysis_runner/_version.py'
     )
     try:
-        resp = requests.get(version_url)
+        resp = requests.get(version_url, timeout=20)
         resp.raise_for_status()
         data = resp.text
     except requests.HTTPError as e:

--- a/sample_metadata/main.py
+++ b/sample_metadata/main.py
@@ -37,6 +37,7 @@ def sample_metadata(data, unused_context):
             f'{AUDIENCE}/api/v1/analysis/{project}/',
             json=sm_data,
             headers={'Authorization': f'Bearer {token}'},
+            timeout=60,
         )
         r.raise_for_status()
         analysis_id = r.text
@@ -54,6 +55,6 @@ def get_identity_token() -> str:
     """
     meta_url = 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity'
     url = f'{meta_url}?audience={AUDIENCE}&format=full'
-    r = requests.get(url=url, headers={'Metadata-Flavor': 'Google'})
+    r = requests.get(url=url, headers={'Metadata-Flavor': 'Google'}, timeout=30)
     r.raise_for_status()
     return r.text

--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -178,7 +178,6 @@ def add_cromwell_routes(
             input_dict=input_dict,
             input_paths=input_jsons,
             project=project,
-            environment=cloud_environment,
         )
 
         url = run_batch_job_and_print_url(

--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -201,7 +201,8 @@ def add_cromwell_routes(
 
             token = get_cromwell_oauth_token()
             headers = {'Authorization': 'Bearer ' + str(token)}
-            req = requests.get(cromwell_metadata_url, headers=headers)
+            # longer timeout because metadata can take a while to fetch
+            req = requests.get(cromwell_metadata_url, headers=headers, timeout=120)
             if not req.ok:
                 raise web.HTTPInternalServerError(
                     reason=req.content.decode() or req.reason

--- a/server/cromwell.py
+++ b/server/cromwell.py
@@ -65,16 +65,16 @@ def add_cromwell_routes(
         dataset = params['dataset']
         access_level = params['accessLevel']
         cloud_environment = 'gcp'
-        server_config = get_server_config()
         output_dir = validate_output_dir(params['output'])
-        environment_config = check_dataset_and_group(
-            server_config=server_config,
+        dataset_config = check_dataset_and_group(
+            server_config=get_server_config(),
             environment=cloud_environment,
             dataset=dataset,
             email=email,
         )
+        environment_config = dataset_config.get(cloud_environment)
         repo = params['repo']
-        check_allowed_repos(server_config, dataset, repo)
+        check_allowed_repos(dataset_config=dataset_config, repo=repo)
         labels = params.get('labels')
 
         project = environment_config.get('projectId')

--- a/server/util.py
+++ b/server/util.py
@@ -67,9 +67,9 @@ def get_email_from_request(request):
         raise web.HTTPForbidden(reason='Invalid authorization header') from e
 
 
-def check_allowed_repos(server_config, dataset, repo):
+def check_allowed_repos(dataset_config, repo):
     """Check that repo is the in server_config allowedRepos for the dataset"""
-    allowed_repos = server_config[dataset]['allowedRepos']
+    allowed_repos = dataset_config['allowedRepos']
     if repo not in allowed_repos:
         raise web.HTTPForbidden(
             reason=(
@@ -118,7 +118,7 @@ def check_dataset_and_group(server_config, environment: str, dataset, email) -> 
             reason=f'{email} is not a member of the {dataset} access group'
         )
 
-    return dataset_config[environment]
+    return dataset_config
 
 
 # pylint: disable=too-many-arguments

--- a/server/util.py
+++ b/server/util.py
@@ -40,7 +40,7 @@ async def _get_hail_version(environment: str) -> str:
     """ASYNC get hail version for the hail server in the local deploy_config"""
     if not environment == 'gcp':
         raise web.HTTPBadRequest(
-            f'Unsupported Hail Batch deploy config environment: {environment}'
+            reason=f'Unsupported Hail Batch deploy config environment: {environment}'
         )
 
     deploy_config = get_deploy_config()

--- a/server/util.py
+++ b/server/util.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-function-args
 """
 Utility methods for analysis-runner server
 """

--- a/server/util.py
+++ b/server/util.py
@@ -24,8 +24,8 @@ ALLOWED_CONTAINER_IMAGE_PREFIXES = (
 )
 DRIVER_IMAGE = os.getenv('DRIVER_IMAGE')
 assert DRIVER_IMAGE
-INFRA = 'gcp'
-CONFIG_PATH_PREFIX = 'gs://cpg-config'
+
+CONFIG_PATH_PREFIXES = {'gcp': 'gs://cpg-config'}
 
 secret_manager = secretmanager.SecretManagerServiceClient()
 publisher = pubsub_v1.PublisherClient()
@@ -36,8 +36,13 @@ def get_server_config() -> dict:
     return json.loads(read_secret(ANALYSIS_RUNNER_PROJECT_ID, 'server-config'))
 
 
-async def _get_hail_version() -> str:
+async def _get_hail_version(environment: str) -> str:
     """ASYNC get hail version for the hail server in the local deploy_config"""
+    if not environment == 'gcp':
+        raise web.HTTPBadRequest(
+            f'Unsupported Hail Batch deploy config environment: {environment}'
+        )
+
     deploy_config = get_deploy_config()
     url = deploy_config.url('batch', f'/api/v1alpha/version')
     async with ClientSession() as session:
@@ -81,7 +86,7 @@ def validate_output_dir(output_dir: str):
     return output_dir.rstrip('/')  # Strip trailing slash.
 
 
-def check_dataset_and_group(server_config, dataset, email):
+def check_dataset_and_group(server_config, environment: str, dataset, email) -> dict:
     """Check that the email address is a member of the {dataset}-access@popgen group"""
     dataset_config = server_config.get(dataset)
     if not dataset_config:
@@ -92,6 +97,19 @@ def check_dataset_and_group(server_config, dataset, email):
             )
         )
 
+    if environment not in dataset_config:
+        raise web.HTTPBadRequest(
+            reason=f'Dataset {dataset} does not support the {environment} environment'
+        )
+
+    # do this to check access-members cache
+    gcp_project = dataset_config.get('gcp', {}).get('projectId')
+
+    if not gcp_project:
+        raise web.HTTPBadRequest(
+            reason=f'The analysis-runner does not support checking group members for the {environment} environment'
+        )
+
     group_members = read_secret(
         dataset_config['projectId'], f'{dataset}-access-members-cache'
     ).split(',')
@@ -99,6 +117,8 @@ def check_dataset_and_group(server_config, dataset, email):
         raise web.HTTPForbidden(
             reason=f'{email} is not a member of the {dataset} access group'
         )
+
+    return dataset_config[environment]
 
 
 # pylint: disable=too-many-arguments
@@ -115,6 +135,7 @@ def get_analysis_runner_metadata(
     driver_image,
     config_path,
     cwd,
+    environment,
     **kwargs,
 ):
     """
@@ -136,15 +157,15 @@ def get_analysis_runner_metadata(
         'driverImage': driver_image,
         'configPath': config_path,
         'cwd': cwd,
-        **kwargs,
+        'environment': environment**kwargs,
     }
 
 
-def run_batch_job_and_print_url(batch, wait):
+def run_batch_job_and_print_url(batch, wait, environment):
     """Call batch.run(), return the URL, and wait for job to  finish if wait=True"""
     bc_batch = batch.run(wait=False)
 
-    deploy_config = get_deploy_config()
+    deploy_config = get_deploy_config(environment)
     url = deploy_config.url('batch', f'/batches/{bc_batch.id}')
 
     if wait:
@@ -164,41 +185,55 @@ def validate_image(container: str, is_test: bool):
     )
 
 
-def write_config(config: dict) -> str:
+def write_config(config: dict, environment: str) -> str:
     """Writes the given config dictionary to a blob and returns its unique path."""
-    config_path = AnyPath(CONFIG_PATH_PREFIX) / (str(uuid.uuid4()) + '.toml')
+    prefix = CONFIG_PATH_PREFIXES.get(environment)
+    if not prefix:
+        raise web.HTTPBadRequest(reason=f'Bad environment for config: {environment}')
+
+    config_path = AnyPath(prefix) / (str(uuid.uuid4()) + '.toml')
     with config_path.open('w') as f:
         toml.dump(config, f)
     return str(config_path)
 
 
 def get_baseline_run_config(
-    project_id, dataset, access_level, output_prefix, driver: str | None = None
+    environment: str,
+    gcp_project_id,
+    dataset,
+    access_level,
+    output_prefix,
+    driver: str | None = None,
 ) -> dict:
     """
     Returns the baseline config of analysis-runner specified default values,
     as well as pre-generated templates with common locations and resources.
     permits overriding the default driver image
     """
+    config_prefix = CONFIG_PATH_PREFIXES.get(environment)
+    if not config_prefix:
+        raise web.HTTPBadRequest(reason=f'Bad environment for config: {environment}')
+
     baseline_config = {
         'hail': {
             'billing_project': dataset,
+            # TODO: how would this work for Azure
             'bucket': f'cpg-{dataset}-hail',
         },
         'workflow': {
             'access_level': access_level,
             'dataset': dataset,
-            'dataset_gcp_project': project_id,
+            'dataset_gcp_project': gcp_project_id,
             'driver_image': driver or DRIVER_IMAGE,
             'output_prefix': output_prefix,
         },
     }
     template_paths = [
-        AnyPath(CONFIG_PATH_PREFIX) / 'templates' / suf
+        AnyPath(config_prefix) / 'templates' / suf
         for suf in [
             'images/images.toml',
             'references/references.toml',
-            f'storage/{INFRA}/{dataset}-{cpg_namespace(access_level)}.toml',
+            f'storage/{environment}/{dataset}-{cpg_namespace(access_level)}.toml',
         ]
     ]
     if missing := [p for p in template_paths if not p.exists()]:


### PR DESCRIPTION
I changed the server-config generation when I migrated to single-stack. And this is the follow-up PR to address that, but also some token pieces for supporting multiple environments from the analysis-runner.

It's locked to only support `gcp`, but should be easier to now support multiple environments.

Context: https://github.com/populationgenomics/cpg-infrastructure/pull/15