### PR TITLE
Pin crypto package in dataproc init script

### DIFF
--- a/dataproc/install_common.sh
+++ b/dataproc/install_common.sh
@@ -34,7 +34,8 @@ pip3 install \
     selenium>=3.8.0 \
     statsmodels \
     cloudpathlib[all] \
-    gnomad
+    gnomad \
+    cryptography==38.0.4
 
 # Install phantomjs with a workaround for the libssl_conf.so on Debian Buster:
 # https://github.com/bazelbuild/rules_closure/issues/351#issuecomment-854628326


### PR DESCRIPTION
Fixes `AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'`

Context: https://centrepopgen.slack.com/archives/C01R7CKJGHM/p1673305981120759