### PR TITLE
Fix disk_usage instructions

### DIFF
--- a/disk_usage/README.md
+++ b/disk_usage/README.md
@@ -6,7 +6,7 @@ explicitly listing all blobs. In contrast to `gsutil du`, we aggregate at the fo
 Example invocation (replace `$DATASET` accordingly):
 
 ```sh
-analysis-runner --dataset $DATASET --cpu 0.5 --access-level standard --output-dir "disk_usage/$(date +'%Y-%m-%d')" --description "disk usage stats" disk_usage.py
+analysis-runner --dataset $DATASET --cpu 0.5 --access-level full --output-dir "disk_usage/$(date +'%Y-%m-%d')" --description "disk usage stats" disk_usage.py
 ```
 
 For datasets with an extremely large number of blobs, consider setting `--no-preemptible`.


### PR DESCRIPTION
The `standard` access level doesn't have permissions to list `test` buckets anymore.