### PR TITLE
Update to copy crams into release bucket script

### DIFF
--- a/scripts/copy_sample_cram_to_release.py
+++ b/scripts/copy_sample_cram_to_release.py
@@ -23,8 +23,7 @@ def copy_to_release(project: str, paths: list[str]):
     Copy many files from main bucket paths to the release bucket with todays date as directory
     """
     today = time.strftime('%Y-%m-%d')
-    #release_path = f'gs://cpg-{project}-release/{today}/'
-    release_path = f'gs://cpg-{project}-test/{today}/'
+    release_path = f'gs://cpg-{project}-release/{today}/'
 
     subprocess.run(['gcloud', 'storage', '--billing-project', project, 'cp', *paths, release_path], check=True)
     logging.info(f'Copied {paths} into {release_path}')
@@ -45,22 +44,19 @@ def main(project: str, samples):
         config = get_config()
         project = config['workflow']['dataset']
 
-    # sample_ids = list(samples)
+    sample_ids = list(samples)
 
-    # # Retrieve latest crams for selected samples
-    # latest_crams = AnalysisApi().get_latest_analysis_for_samples_and_type(
-    #     AnalysisType('cram'), project, request_body=sample_ids
-    # )
+    # Retrieve latest crams for selected samples
+    latest_crams = AnalysisApi().get_latest_analysis_for_samples_and_type(
+        AnalysisType('cram'), project, request_body=sample_ids
+    )
 
-    # # Get all paths of files to be copied to release
-    # cram_paths = []
-    # for cram in latest_crams:
-    #     #cram_paths.append(cram['output'])
-    #     cram_paths.append(cram['output'] + '.crai')
-    cram_paths = ['gs://cpg-perth-neuro-test/ed_test_20230314/test1.rtf',
-                  'gs://cpg-perth-neuro-test/ed_test_20230314/test2.rtf',
-                  'gs://cpg-perth-neuro-test/ed_test_20230314/test3.rtf',
-                  'gs://cpg-perth-neuro-test/ed_test_20230314/test4.rtf']
+    # Get all paths of files to be copied to release
+    cram_paths = []
+    for cram in latest_crams:
+        cram_paths.append(cram['output'])
+        cram_paths.append(cram['output'] + '.crai')
+
     copy_to_release(project, cram_paths)
 
 

--- a/scripts/copy_sample_cram_to_release.py
+++ b/scripts/copy_sample_cram_to_release.py
@@ -9,37 +9,41 @@ each sample listed into the project's release bucket.
 import logging
 import sys
 import subprocess
+import time
 import click
 
 # pylint: disable=E0401,E0611
+from cpg_utils.config import get_config
 from sample_metadata.apis import AnalysisApi
 from sample_metadata.models import AnalysisType
 
 
-def copy_to_release(project: str, path: str):
+def copy_to_release(project: str, paths: list[str]):
     """
-    Copy a single file from a main bucket path to the equivalent release bucket
+    Copy many files from main bucket paths to the release bucket with todays date as directory
     """
-    release_path = path.replace(
-        f'cpg-{project}-main',
-        f'cpg-{project}-release',
-    )
+    today = time.strftime('%Y-%m-%d')
+    #release_path = f'gs://cpg-{project}-release/{today}/'
+    release_path = f'gs://cpg-{project}-test/{today}/'
 
-    subprocess.run(['gsutil', 'cp', '-u', project, path, release_path], check=True)
-    logging.info(f'Copied {release_path}')
+    subprocess.run(['gcloud', 'storage', '--billing-project', project, 'cp', *paths, release_path], check=True)
+    logging.info(f'Copied {paths} into {release_path}')
 
 
 @click.command()
-@click.option('--project', '-p', help='Metamist name of the project', required=True)
+@click.option('--project', '-p', help='Metamist name of the project', default="")
 @click.argument('samples', nargs=-1)
 def main(project: str, samples):
     """
 
     Parameters
     ----------
-    project :   a metamist project name
+    project :   a metamist project name, optional as it can be pulled from the AR config
     samples :   a list of sample ids to copy to the release bucket
     """
+    if not project:
+        config = get_config()
+        project = config['workflow']['dataset']
 
     sample_ids = list(samples)
 
@@ -48,10 +52,13 @@ def main(project: str, samples):
         AnalysisType('cram'), project, request_body=sample_ids
     )
 
-    # Copy files to test
+    # Get all paths of files to be copied to release
+    cram_paths = []
     for cram in latest_crams:
-        copy_to_release(project, cram['output'])
-        copy_to_release(project, cram['output'] + '.crai')
+        #cram_paths.append(cram['output'])
+        cram_paths.append(cram['output'] + '.crai')
+
+    copy_to_release(project, cram_paths)
 
 
 if __name__ == '__main__':

--- a/scripts/copy_sample_cram_to_release.py
+++ b/scripts/copy_sample_cram_to_release.py
@@ -25,12 +25,15 @@ def copy_to_release(project: str, paths: list[str]):
     today = time.strftime('%Y-%m-%d')
     release_path = f'gs://cpg-{project}-release/{today}/'
 
-    subprocess.run(['gcloud', 'storage', '--billing-project', project, 'cp', *paths, release_path], check=True)
+    subprocess.run(
+        ['gcloud', 'storage', '--billing-project', project, 'cp', *paths, release_path],
+        check=True,
+    )
     logging.info(f'Copied {paths} into {release_path}')
 
 
 @click.command()
-@click.option('--project', '-p', help='Metamist name of the project', default="")
+@click.option('--project', '-p', help='Metamist name of the project', default='')
 @click.argument('samples', nargs=-1)
 def main(project: str, samples):
     """

--- a/scripts/copy_sample_cram_to_release.py
+++ b/scripts/copy_sample_cram_to_release.py
@@ -45,19 +45,22 @@ def main(project: str, samples):
         config = get_config()
         project = config['workflow']['dataset']
 
-    sample_ids = list(samples)
+    # sample_ids = list(samples)
 
-    # Retrieve latest crams for selected samples
-    latest_crams = AnalysisApi().get_latest_analysis_for_samples_and_type(
-        AnalysisType('cram'), project, request_body=sample_ids
-    )
+    # # Retrieve latest crams for selected samples
+    # latest_crams = AnalysisApi().get_latest_analysis_for_samples_and_type(
+    #     AnalysisType('cram'), project, request_body=sample_ids
+    # )
 
-    # Get all paths of files to be copied to release
-    cram_paths = []
-    for cram in latest_crams:
-        #cram_paths.append(cram['output'])
-        cram_paths.append(cram['output'] + '.crai')
-
+    # # Get all paths of files to be copied to release
+    # cram_paths = []
+    # for cram in latest_crams:
+    #     #cram_paths.append(cram['output'])
+    #     cram_paths.append(cram['output'] + '.crai')
+    cram_paths = ['gs://cpg-perth-neuro-test/ed_test_20230314/test1.rtf',
+                  'gs://cpg-perth-neuro-test/ed_test_20230314/test2.rtf',
+                  'gs://cpg-perth-neuro-test/ed_test_20230314/test3.rtf',
+                  'gs://cpg-perth-neuro-test/ed_test_20230314/test4.rtf']
     copy_to_release(project, cram_paths)
 
 


### PR DESCRIPTION
Updated the script to use `gcloud storage cp` in favour of `gsutil cp`, and change the destination to `release/<date>` where `<date>` is todays date, e.g. `2022-03-14`, instead of the initial path to the cram replicated in release.

`gcloud storage --billing-project <project> cp <files> gs://cpg-<project>-release/<date>` 
copies multiple files in parallel into a directory in the release bucket with today's date.

