### PR TITLE
Untar to disk

### DIFF
--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -76,7 +76,7 @@ def untar_gz_files(
             for member in tar.getnames():
                 tar.extract(member, path=os.path.join(f'gs://{bucket_name}',subdir, destination, member))
                 #output_blob.upload_from_file(file_object)
-                logging.info(f'{member} extracted to {os.path.join(subdir, destination, member)}')
+                logging.info(f'{member} extracted to {os.path.join(bucket_name, subdir, destination, member)}')
 
 
 @click.command()

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -72,11 +72,12 @@ def untar_gz_files(
         input_blob = input_bucket.get_blob(blob_name).download_as_string()
         with tarfile.open(fileobj=io.BytesIO(input_blob)) as tar:
             logging.info(f'Untaring {blob_name}')
-
-            for member in tar.getnames():
-                tar.extract(member, path=f'gs://{bucket_name}/{subdir}/{destination}/')
+            tar.extractall(path=f'./{destination}/')
+            logging.info(f'extracted tarball to gs://{bucket_name}/{subdir}/{destination}/')
+            #for member in tar.getnames():
+            #    tar.extract(member, path=f'gs://{bucket_name}/{subdir}/{destination}/')
                 #output_blob.upload_from_file(file_object)
-                logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
+            #    logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
 
 
 @click.command()

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -74,9 +74,9 @@ def untar_gz_files(
             logging.info(f'Untaring {blob_name}')
 
             for member in tar.getnames():
-                tar.extract(member, path=os.path.join(f'gs://{bucket_name}',subdir, destination, member))
+                tar.extract(member, path=f'gs://{bucket_name}/{subdir}/{destination}/')
                 #output_blob.upload_from_file(file_object)
-                logging.info(f'{member} extracted to {os.path.join(bucket_name, subdir, destination, member)}')
+                logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
 
 
 @click.command()

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -72,10 +72,15 @@ def untar_gz_files(
         input_blob = input_bucket.get_blob(blob_name).download_as_string()
         with tarfile.open(fileobj=io.BytesIO(input_blob)) as tar:
             logging.info(f'Untaring {blob_name}')
-            tar.extractall(path=f'./{destination}/')
-            logging.info(f'extracted tarball to gs://{bucket_name}/{subdir}/{destination}/')
-            #for member in tar.getnames():
-            #    tar.extract(member, path=f'gs://{bucket_name}/{subdir}/{destination}/')
+            #tar.extractall(path=f'./{destination}/')
+            #logging.info(f'extracted tarball to gs://{bucket_name}/{subdir}/{destination}/')
+            for member in tar.getnames():
+                tar.extract(member, path=f'./{blob_name}/{member}')
+                output_blob = input_bucket.blob(
+                    os.path.join(subdir, destination, member)
+                )
+                output_blob.upload_from_filename(f'./{blob_name}/{member}')
+                logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
                 #output_blob.upload_from_file(file_object)
             #    logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
 

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -74,7 +74,7 @@ def untar_gz_files(
             logging.info(f'Untaring {blob_name}')
 
             for member in tar.getnames():
-                tar.extract(member, path=os.path.join(subdir, destination, member))
+                tar.extract(member, path=os.path.join(f'gs://{bucket_name}',subdir, destination, member))
                 #output_blob.upload_from_file(file_object)
                 logging.info(f'{member} extracted to {os.path.join(subdir, destination, member)}')
 

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -75,7 +75,7 @@ def untar_gz_files(
             #tar.extractall(path=f'./{destination}/')
             #logging.info(f'extracted tarball to gs://{bucket_name}/{subdir}/{destination}/')
             for member in tar.getnames():
-                tar.extract(member, path=f'./{blob_name}/{member}')
+                tar.extract(member, path=f'./{blob_name}')
                 output_blob = input_bucket.blob(
                     os.path.join(subdir, destination, member)
                 )

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -72,17 +72,15 @@ def untar_gz_files(
         input_blob = input_bucket.get_blob(blob_name).download_as_string()
         with tarfile.open(fileobj=io.BytesIO(input_blob)) as tar:
             logging.info(f'Untaring {blob_name}')
-            #tar.extractall(path=f'./{destination}/')
-            #logging.info(f'extracted tarball to gs://{bucket_name}/{subdir}/{destination}/')
             for member in tar.getnames():
                 tar.extract(member, path=f'./{blob_name}')
                 output_blob = input_bucket.blob(
                     os.path.join(subdir, destination, member)
                 )
                 output_blob.upload_from_filename(f'./{blob_name}/{member}')
-                logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
-                #output_blob.upload_from_file(file_object)
-            #    logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/')
+                logging.info(
+                    f'{member} extracted to gs://{bucket_name}/{subdir}/{destination}/{member}'
+                )
 
 
 @click.command()

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -76,7 +76,7 @@ def untar_gz_files(
             for member in tar.getnames():
                 tar.extract(member, path=os.path.join(subdir, destination, member))
                 #output_blob.upload_from_file(file_object)
-                logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/')
+                logging.info(f'{member} extracted to {os.path.join(subdir, destination, member)}')
 
 
 @click.command()

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -74,11 +74,8 @@ def untar_gz_files(
             logging.info(f'Untaring {blob_name}')
 
             for member in tar.getnames():
-                file_object = tar.extractfile(member)
-                output_blob = input_bucket.blob(
-                    os.path.join(subdir, destination, member)
-                )
-                output_blob.upload_from_file(file_object)
+                tar.extract(member, path=os.path.join(subdir, destination, member))
+                #output_blob.upload_from_file(file_object)
                 logging.info(f'{member} extracted to gs://{bucket_name}/{subdir}/')
 
 


### PR DESCRIPTION
This change swaps the `extractfile` method on the tar members to `extract`. 
This passes the extracted object to the disk, rather than keeping it in memory. From the disk, the file can be uploaded to the blob path in the bucket from the location it was saved to disk.