### PR TITLE
shuffle original script with a wrapper

### DIFF
--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -2,143 +2,85 @@
 
 
 """
-Given a gcp directory, extract all .tar.gz files in the directory
-into output_dir defined in the call to analysis runner
+Given a single TAG.GZ, extract and upload
 """
 
 import logging
 import os
-import re
 import subprocess
 import sys
 import click
 
 # pylint: disable=E0401,E0611
-from cpg_utils.config import get_config
 from google.cloud import storage
-
-RMATCH_STR = r'gs://(?P<bucket>[\w-]+)/(?P<suffix>.+)/'
-path_pattern = re.compile(RMATCH_STR)
 
 client = storage.Client()
 
 
-def get_path_components_from_path(path):
+@click.command()
+@click.option('--bucket', help='', required=True)
+@click.option('--subdir', help='', required=True)
+@click.option('--blob_name', help='', required=True)
+@click.option('--outdir', help='', required=True)
+def main(bucket: str, subdir: str, blob_name: str, outdir: str):
     """
-    Returns the bucket_name and subdir for GS only paths
-    Uses regex to match the bucket name and the subdirectory.
+    runs an extraction and upload for a single file
+
+    TODO - could make this even easier by having the wrapper
+    TODO - copy the single tarball into the job image
+    TODO - leaving extraction and upload as the only tasks
+
+    :param bucket: str, name of the bucket to connect to
+    :param subdir: str, name of the path within the bucket
+    :param blob_name: str, name of the tarball
+    :param outdir: str, where to write to
     """
 
-    path_components = (path_pattern.match(path)).groups()
+    input_bucket = client.get_bucket(bucket)
 
-    bucket_name = path_components[0]
-    subdir = path_components[1]
+    # Make the extraction directory on the disk
+    if not os.path.exists(f'./{subdir}'):
+        os.makedirs(f'./{subdir}')
+        os.makedirs(f'./{subdir}/extracted')
 
-    return bucket_name, subdir
+    # Download and extract the tarball
+    input_bucket.get_blob(blob_name).download_to_filename(blob_name)
+    logging.info(f'Untaring {blob_name}')
+    subprocess.run(
+        ['tar', '-xzf', f'{blob_name}', '-C', f'./{subdir}/extracted'],
+        check=True,
+    )
+    logging.info(f'Untared {blob_name}')
 
+    extracted_from_tarball = os.listdir(f'./{subdir}/extracted')
 
-def get_tarballs_from_path(bucket_name: str, subdir: str):
-    """
-    Checks a gs://bucket/subdir/ path for .tar.gz files
-    Returns a list of .tar.gz blob paths found in the subdirectory
-    """
+    # Check if the tarball compressed a single directory, if yes then get files inside
+    if os.path.isdir(f'./{subdir}/extracted/{extracted_from_tarball[0]}'):
+        is_directory = True
+        folder = extracted_from_tarball[0]
+        extracted_files = os.listdir(f'./{subdir}/extracted/{folder}')
+    else:
+        is_directory = False
+        extracted_files = os.listdir(f'./{subdir}/extracted')
+    logging.info(f'Extracted {extracted_files}')
 
-    blob_names = []
-    for blob in client.list_blobs(bucket_name, prefix=(subdir + '/'), delimiter='/'):
-        if not blob.name.endswith('.tar.gz'):
-            continue
-        blob_names.append(blob.name)
+    # Iterate through extracted files, upload them to bucket, then delete them
+    for file in extracted_files:
+        output_blob = input_bucket.blob(os.path.join(subdir, outdir, file))
 
-    logging.info(f'{len(blob_names)} .tar.gz files found in {subdir} of {bucket_name}')
-
-    return blob_names
-
-
-def untar_gz_files(
-    bucket_name: str,
-    subdir: str,
-    blob_names: list[str],
-    destination: str,
-):
-    """
-    Downloads the .tar.gz files in blob_names to the disk
-    Extracts the files from the tarball into a folder called extracted
-    Uploads and then deletes each extracted file, one by one.
-    Deletes the original downloaded tarball after all its files are uploaded.
-
-    The uploaded files end up in a directory denoted by the destination
-    appended to the original gs:// search path.
-    """
-    input_bucket = client.get_bucket(bucket_name)
-
-    for blob_name in blob_names:
-        # Make the extraction directory on the disk
-        if not os.path.exists(f'./{subdir}'):
-            os.makedirs(f'./{subdir}')
-            os.makedirs(f'./{subdir}/extracted')
-
-        # Download and extract the tarball
-        input_bucket.get_blob(blob_name).download_to_filename(blob_name)
-        logging.info(f'Untaring {blob_name}')
-        subprocess.run(
-            ['tar', '-xzf', f'{blob_name}', '-C', f'./{subdir}/extracted'],
-            check=True,
-        )
-        logging.info(f'Untared {blob_name}')
-
-        extracted_from_tarball = os.listdir(f'./{subdir}/extracted')
-
-        # Check if the tarball compressed a single directory, if yes then get files inside
-        if os.path.isdir(f'./{subdir}/extracted/{extracted_from_tarball[0]}'):
-            is_directory = True
-            folder = extracted_from_tarball[0]
-            extracted_files = os.listdir(f'./{subdir}/extracted/{folder}')
+        if is_directory:
+            filepath = f'./{subdir}/extracted/{folder}/{file}'
         else:
-            is_directory = False
-            extracted_files = os.listdir(f'./{subdir}/extracted')
-        logging.info(f'Extracted {extracted_files}')
+            filepath = f'./{subdir}/extracted/{file}'
 
-        # Iterate through extracted files, upload them to bucket, then delete them
-        for file in extracted_files:
-            output_blob = input_bucket.blob(os.path.join(subdir, destination, file))
+        output_blob.upload_from_filename(filepath)
+        logging.info(f'Uploaded {file} to gs://{bucket}/{subdir}/{outdir}/')
 
-            if is_directory:
-                filepath = f'./{subdir}/extracted/{folder}/{file}'
-            else:
-                filepath = f'./{subdir}/extracted/{file}'
-
-            output_blob.upload_from_filename(filepath)
-            logging.info(
-                f'Uploaded {file} to gs://{bucket_name}/{subdir}/{destination}/'
-            )
-
-            # Delete file after upload
-            subprocess.run(['rm', f'{filepath}'], check=True)
-            logging.info(f'Deleted {file} from disk')
-
-        # Delete tarball after all extracted files uploaded & deleted
-        subprocess.run(['rm', f'{blob_name}'], check=True)
-        logging.info(f'Deleted tarball {blob_name}')
+        # Delete file after upload
+        subprocess.run(['rm', f'{filepath}'], check=True)
+        logging.info(f'Deleted {file} from disk')
 
     logging.info('All tarballs extracted and uploaded. Finishing...')
-
-
-@click.command()
-@click.option('--search-path', '-p', help='GCP bucket/directory to search', default='')
-def main(search_path: str):
-    """
-    Parameters
-    ----------
-    search_path :   The GCP directory containing the .tar.gz files
-    """
-    config = get_config()
-    output_dir = config['workflow']['output_prefix']
-
-    bucket_name, subdir = get_path_components_from_path(search_path)
-
-    blobs = get_tarballs_from_path(bucket_name, subdir)
-
-    untar_gz_files(bucket_name, subdir, blobs, output_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -86,7 +86,7 @@ def main(search_path: str):
 
     if len(blobs) == 0:
         logging.info('Nothing to do, quitting')
-        exit(0)
+        sys.exit(0)
 
     # iterate over targets, set each one off in parallel
     for blobname, blobsize in blobs:

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+"""
+wrapper script for the un-tar script
+wrapped to modulate the batch job storage
+"""
+
+import logging
+import os
+import re
+import sys
+
+import click
+from google.cloud import storage
+
+from cpg_workflows.batch import get_batch
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job
+
+
+CLIENT = storage.Client()
+RMATCH_STR = r'gs://(?P<bucket>[\w-]+)/(?P<suffix>.+)/'
+PATH_PATTERN = re.compile(RMATCH_STR)
+GB = 1024 * 1024 * 1024  # dollars
+UNZIP_SCRIPT = os.path.join(os.path.dirname(__file__), 'untar_gz_files.py')
+
+
+def get_path_components_from_path(path):
+    """
+    Returns the bucket_name and subdir for GS only paths
+    Uses regex to match the bucket name and the subdirectory.
+    """
+
+    path_components = (PATH_PATTERN.match(path)).groups()
+
+    bucket_name = path_components[0]
+    subdir = path_components[1]
+
+    return bucket_name, subdir
+
+
+def get_tarballs_from_path(bucket_name: str, subdir: str) -> list[tuple[str, int]]:
+    """
+    Checks a gs://bucket/subdir/ path for .tar.gz files
+    Returns a list of:
+        - .tar.gz blob paths found in the subdirectory
+        - the size of image to use when unpacking the tarball
+    """
+
+    blob_details = []
+    for blob in CLIENT.list_blobs(bucket_name, prefix=(subdir + '/'), delimiter='/'):
+        if not blob.name.endswith('.tar.gz'):
+            continue
+
+        # image size is double the tar size in GB, or 30GB
+        # whichever is larger
+        job_gb = max([30, (blob.size // GB) * 2])
+
+        blob_details.append((blob.name, job_gb))
+
+    logging.info(
+        f'{len(blob_details)} .tar.gz files found in {subdir} of {bucket_name}'
+    )
+
+    return blob_details
+
+
+@click.command()
+@click.option(
+    '--search-path', '-p', help='GCP bucket/directory to search', required=True
+)
+def main(search_path: str):
+    """
+    Who runs the world? main()
+
+    Args:
+        search_path (str): path to find tarballs in
+    """
+
+    config = get_config()
+    output_dir = config['workflow']['output_prefix']
+
+    bucket_name, subdir = get_path_components_from_path(search_path)
+
+    blobs = get_tarballs_from_path(bucket_name, subdir)
+
+    if len(blobs) == 0:
+        logging.info('Nothing to do, quitting')
+        exit(0)
+
+    # iterate over targets, set each one off in parallel
+    for blobname, blobsize in blobs:
+        # create and config job
+        job = get_batch().new_job(name=f'decompress {blobname}')
+        job.image(get_config()['workflow']['driver_image'])
+        job.cpu(2)
+        job.storage(blobsize)
+        authenticate_cloud_credentials_in_job(job)
+        job.command(
+            f'{UNZIP_SCRIPT} '
+            f'--bucket {bucket_name} '
+            f'--subdir {subdir} '
+            f'--blob_name {blobname} '
+            f'--outdir {output_dir}'
+        )
+
+    get_batch().run(wait=False)
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+        datefmt='%Y-%M-%d %H:%M:%S',
+        stream=sys.stderr,
+    )
+
+    main()  # pylint: disable=no-value-for-parameter

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -15,7 +15,7 @@ from google.cloud import storage
 
 from cpg_workflows.batch import get_batch
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job
+from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, copy_common_env
 
 
 CLIENT = storage.Client()
@@ -96,6 +96,7 @@ def main(search_path: str):
         job.cpu(2)
         job.storage(blobsize)
         authenticate_cloud_credentials_in_job(job)
+        copy_common_env(job)
         job.command(
             f'{UNZIP_SCRIPT} '
             f'--bucket {bucket_name} '

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -107,6 +107,7 @@ def main(search_path: str):
 
     get_batch().run(wait=False)
 
+
 if __name__ == '__main__':
     logging.basicConfig(
         level=logging.INFO,


### PR DESCRIPTION
this is a concept PR, feel free to ignore or rewrite - 

-  The wrapper script is called as an analysis-runner job
- This parses the given directory for all the available TAR.GZ files, storing the name and size
    - The stored size is the greater of (size in GB * 2), or 30
- For each of those TAR archives:
    - create a batch job with 2 cores (?)
    - authenticate the job so that it will be able to communicate with GCP
    - assign the required amount of storage
    - create a single unpack/upload job (the core method from your previous workflow, but as a dedicated script)
    - each job may also need the `copy_common_env` method called to copy in any required environment variables... unsure
- run the collected batch jobs

Reasoning: 

- this encourages parallel unpack/uploads if there are multiple TAR files
- storage for each job is appropriate to the volume of data being unpacked
- ???
- PROFIT!

Bad things...?: 

- This assigns a high minimum storage volume, but for a small TAR file the job would also be near instant, so a negligible instance cost
- In a hypothetical situation where a directory contains a billion TAR files, this would try to spawn a billion batch jobs and that probably won't work