### PR TITLE
recursively iterate through extracted paths

### DIFF
--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -7,6 +7,7 @@ Given a single TAG.GZ, extract and upload
 
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 import click
@@ -52,26 +53,24 @@ def main(bucket: str, subdir: str, blob_name: str, outdir: str):
     )
     logging.info(f'Untared {blob_name}')
 
-    extracted_from_tarball = os.listdir(f'./{subdir}/extracted')
+    # Recursively get all paths to everything extracted from tarball
+    extracted_from_tarball = pathlib.Path(f'./{subdir}/extracted')
+    all_extracted_paths = [str(path) for path in list(extracted_from_tarball.rglob('*'))]
+
+    # Discard paths that are directories, keep paths to files
+    extracted_file_paths = []
+    for extracted_path in all_extracted_paths:
+        if not os.path.isdir(extracted_path):
+            extracted_file_paths.append(extracted_path)
+            
 
     # Check if the tarball compressed a single directory, if yes then get files inside
-    if os.path.isdir(f'./{subdir}/extracted/{extracted_from_tarball[0]}'):
-        is_directory = True
-        folder = extracted_from_tarball[0]
-        extracted_files = os.listdir(f'./{subdir}/extracted/{folder}')
-    else:
-        is_directory = False
-        extracted_files = os.listdir(f'./{subdir}/extracted')
-    logging.info(f'Extracted {extracted_files}')
+    logging.info(f'Extracted {[os.path.basename(path) for path in extracted_file_paths]}')
 
     # Iterate through extracted files, upload them to bucket, then delete them
-    for file in extracted_files:
+    for filepath in extracted_file_paths:
+        file = os.path.basename(filepath)
         output_blob = input_bucket.blob(os.path.join(subdir, outdir, file))
-
-        if is_directory:
-            filepath = f'./{subdir}/extracted/{folder}/{file}'
-        else:
-            filepath = f'./{subdir}/extracted/{file}'
 
         output_blob.upload_from_filename(filepath)
         logging.info(f'Uploaded {file} to gs://{bucket}/{subdir}/{outdir}/')

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -55,15 +55,10 @@ def main(bucket: str, subdir: str, blob_name: str, outdir: str):
 
     # Recursively get all paths to everything extracted from tarball
     extracted_from_tarball = pathlib.Path(f'./{subdir}/extracted')
-    all_extracted_paths = [
-        str(path) for path in list(extracted_from_tarball.rglob('*'))
+    extracted_file_paths = [
+        str(path) for path in extracted_from_tarball.rglob('*') 
+        if not path.is_dir()
     ]
-
-    # Discard paths that are directories, keep paths to files
-    extracted_file_paths = []
-    for extracted_path in all_extracted_paths:
-        if not os.path.isdir(extracted_path):
-            extracted_file_paths.append(extracted_path)
 
     # Check if the tarball compressed a single directory, if yes then get files inside
     logging.info(

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -55,17 +55,20 @@ def main(bucket: str, subdir: str, blob_name: str, outdir: str):
 
     # Recursively get all paths to everything extracted from tarball
     extracted_from_tarball = pathlib.Path(f'./{subdir}/extracted')
-    all_extracted_paths = [str(path) for path in list(extracted_from_tarball.rglob('*'))]
+    all_extracted_paths = [
+        str(path) for path in list(extracted_from_tarball.rglob('*'))
+    ]
 
     # Discard paths that are directories, keep paths to files
     extracted_file_paths = []
     for extracted_path in all_extracted_paths:
         if not os.path.isdir(extracted_path):
             extracted_file_paths.append(extracted_path)
-            
 
     # Check if the tarball compressed a single directory, if yes then get files inside
-    logging.info(f'Extracted {[os.path.basename(path) for path in extracted_file_paths]}')
+    logging.info(
+        f'Extracted {[os.path.basename(path) for path in extracted_file_paths]}'
+    )
 
     # Iterate through extracted files, upload them to bucket, then delete them
     for filepath in extracted_file_paths:

--- a/scripts/untar_gz_files.py
+++ b/scripts/untar_gz_files.py
@@ -56,8 +56,7 @@ def main(bucket: str, subdir: str, blob_name: str, outdir: str):
     # Recursively get all paths to everything extracted from tarball
     extracted_from_tarball = pathlib.Path(f'./{subdir}/extracted')
     extracted_file_paths = [
-        str(path) for path in extracted_from_tarball.rglob('*') 
-        if not path.is_dir()
+        str(path) for path in extracted_from_tarball.rglob('*') if not path.is_dir()
     ]
 
     # Check if the tarball compressed a single directory, if yes then get files inside

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -55,9 +55,9 @@ def get_tarballs_from_path(bucket_name: str, subdir: str) -> list[tuple[str, int
         if not blob.name.endswith('.tar.gz'):
             continue
 
-        # image size is double the tar size in GB, or 30GB
+        # image size is double and a half the tar size in GB, or 30GB
         # whichever is larger
-        job_gb = max([30, (blob.size // GB) * 2])
+        job_gb = max([30, (blob.size // GB) * 2.5])
 
         blob_details.append((blob.name, job_gb))
 
@@ -96,7 +96,7 @@ def main(search_path: str):
         # create and config job
         job = get_batch().new_job(name=f'decompress {blobname}')
         job.image(get_config()['workflow']['driver_image'])
-        job.cpu(2)
+        job.cpu(4)
         job.storage(f'{blobsize}Gi')
         authenticate_cloud_credentials_in_job(job)
         copy_common_env(job)

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -57,7 +57,7 @@ def get_tarballs_from_path(bucket_name: str, subdir: str) -> list[tuple[str, int
 
         # image size is double and a half the tar size in GB, or 30GB
         # whichever is larger
-        job_gb = max([30, (blob.size // GB) * 2.5])
+        job_gb = max([30, int((blob.size // GB) * 2.5)])
 
         blob_details.append((blob.name, job_gb))
 

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -97,7 +97,7 @@ def main(search_path: str):
         job = get_batch().new_job(name=f'decompress {blobname}')
         job.image(get_config()['workflow']['driver_image'])
         job.cpu(2)
-        job.storage(str(blobsize) + 'Gi')
+        job.storage(f'{blobsize}Gi')
         authenticate_cloud_credentials_in_job(job)
         copy_common_env(job)
         prepare_git_job(


### PR DESCRIPTION
Unfortunately, the tarballs containing sequence data contained subdirectories, which the code could not handle. 

I've refactored the block to use Pathlib's `rglob('*')` which recursively returns everything in a directory. We then iterate through the returned paths and discard any that are a directory, leaving only file paths.

Then we take the base file names from the paths, and use these to create our output blobs in the `/subdir/extracted` folder of the bucket. We upload to each blob from the full path to the extracted file on the disk.