### PR TITLE
Remove crams + indexes and somaliers from bucket directory

### DIFF
--- a/scripts/delete_sample_crams.py
+++ b/scripts/delete_sample_crams.py
@@ -63,6 +63,7 @@ def main(delete_path: str, somaliers: bool, samples):
     ----------
     delete_path :   a gcp path containing the crams to delete.
                         e.g. gs://cpg-project-main/exome/cram
+    somaliers   :   flag if .cram.somalier files should be deleted too
     samples     :   a list of sample ids to copy to the release bucket
     """
 

--- a/scripts/delete_sample_crams.py
+++ b/scripts/delete_sample_crams.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+
+"""
+Given a bucket path and sample IDs, deletes cram files in
+the path for each sample listed.
+"""
+
+import logging
+import sys
+import subprocess
+import click
+
+def check_paths_exist(paths: list[str]):
+    """
+    Checks a list of gs:// paths to see if they point to an existing blob
+    Logs the invalid paths if any are found
+    """
+    invalid_paths = False
+    for path in paths:
+        # gsutil ls <path> returns '<path>\n' if path exists
+        result = subprocess.run(
+            ['gsutil', 'ls', path], check=True, capture_output=True, text=True
+        ).stdout.strip('\n')
+        if result == path:
+            continue
+        # If path does not exist, log the path and set invalid_paths to True
+        logging.info(f'Invalid path: {path}')
+        invalid_paths = True
+
+    if invalid_paths:
+        return False
+    return True
+
+
+def delete_from_bucket(paths: list[str]):
+    """
+    Delete CRAM and CRAM.crai files from bucket paths
+    """
+
+    subprocess.run(
+        ['gsutil', 'rm', *paths],
+        check=True,
+    )
+    logging.info(f'Deleted items: {paths}')
+
+
+@click.command()
+@click.option('--delete-path', '-d', help='GCP path to CRAMs to delete', required=True)
+@click.argument('samples', nargs=-1)
+def main(delete_path: str, samples):
+    """
+
+    Parameters
+    ----------
+    delete_path :   a gcp path containing the crams to delete.
+                        e.g. gs://cpg-project-main/exome/cram
+    samples     :   a list of sample ids to copy to the release bucket
+    """
+
+    sample_ids = list(samples)
+
+    # Generate the paths to the crams and crais to be deleted
+    cram_paths = []
+    for sample in sample_ids:
+        cram_paths.append(f'{delete_path}/{sample}.cram')
+        cram_paths.append(f'{delete_path}/{sample}.cram.crai')
+
+    # Check if all paths are valid and execute the rm commands if they are
+    if check_paths_exist(cram_paths):
+        delete_from_bucket(cram_paths)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+        datefmt='%Y-%M-%d %H:%M:%S',
+        stream=sys.stderr,
+    )
+
+    main()  # pylint: disable=no-value-for-parameter

--- a/scripts/delete_sample_crams.py
+++ b/scripts/delete_sample_crams.py
@@ -11,6 +11,7 @@ import sys
 import subprocess
 import click
 
+
 def check_paths_exist(paths: list[str]):
     """
     Checks a list of gs:// paths to see if they point to an existing blob
@@ -47,8 +48,15 @@ def delete_from_bucket(paths: list[str]):
 
 @click.command()
 @click.option('--delete-path', '-d', help='GCP path to CRAMs to delete', required=True)
+@click.option(
+    '--somaliers',
+    '-s',
+    help='Also delete cram.somalier files',
+    is_flag=True,
+    default=False,
+)
 @click.argument('samples', nargs=-1)
-def main(delete_path: str, samples):
+def main(delete_path: str, somaliers: bool, samples):
     """
 
     Parameters
@@ -65,6 +73,8 @@ def main(delete_path: str, samples):
     for sample in sample_ids:
         cram_paths.append(f'{delete_path}/{sample}.cram')
         cram_paths.append(f'{delete_path}/{sample}.cram.crai')
+        if somaliers:
+            cram_paths.append(f'{delete_path}/{sample}.cram.somalier')
 
     # Check if all paths are valid and execute the rm commands if they are
     if check_paths_exist(cram_paths):


### PR DESCRIPTION
This script will delete CRAMs + indexes for provided samples at the specified bucket path.

For example, if a `genome` sequence has ingested as `type: exome` and the sequence goes through alignment, a bogus CRAM is created in the `main/exome/cram/` path in the bucket. 

Context: https://github.com/populationgenomics/seqr-private/issues/73

I have to say, it seems like a data loss risk to just let this script loose in the main branch... 
Are there any additional steps or checks that should be included to mitigate risk before merging this? Or perhaps a different repo where it would be safer?