### PR TITLE
Generic files to release

### DIFF
--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -98,7 +98,7 @@ def main(project: str, billing_project: str, bucket: str, url_file: str):
     blob.download_to_filename(url_file)
 
     with open(url_file, 'r', encoding='ascii') as f:
-        paths = f.readlines()
+        paths = [line.rstrip() for line in f]
 
     # Check if all paths are valid and execute the copy commands if they are
     if check_paths_exist(paths):

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -93,7 +93,7 @@ def main(project: str, billing_project: str, url_file: str):
     path_components = get_path_components_from_gcp_path(url_file)
 
     bucket = path_components['bucket']
-    file_name = os.path.join(path_components['subdir'], path_components['file'])
+    file_name = os.path.join(path_components['suffix'], path_components['file'])
 
     input_bucket = client.get_bucket(bucket)
     blob = input_bucket.get_blob(file_name)

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -69,16 +69,15 @@ def copy_to_release(project: str, billing_project: str, paths: list[str]):
 @click.command()
 @click.option('--project', '-p', help='Metamist name of the project', default='')
 @click.option('--billing-project', '-b', help='The GCP billing project to use')
-@click.argument('url_file')
-def main(project: str, billing_project: str, url_file: str):
+@click.argument('urls_file_path')
+def main(project: str, billing_project: str, urls_file_path: str):
     """
 
     Parameters
     ----------
-    project :   a metamist project name, optional as it can be pulled from the AR config
+    project :   a metamist dataset name, optional as it can be pulled from the AR config
     billing_project :    a GCP project ID to bill to
-    bucket :    the GCP bucket containing the data to copy
-    url_file :   a full GS path to a file containing the links to move into the release bucket
+    urls_file_path :   a full GS path to a file containing the links to move into the release bucket
     """
     if not project:
         config = get_config()
@@ -87,10 +86,10 @@ def main(project: str, billing_project: str, url_file: str):
     if not billing_project:
         billing_project = project
 
-    if not url_file.startswith(f'gs://'):
+    if not urls_file_path.startswith(f'gs://'):
         raise ValueError('url_file must be a fully qualified GS path')
 
-    path_components = get_path_components_from_gcp_path(url_file)
+    path_components = get_path_components_from_gcp_path(urls_file_path)
 
     bucket = path_components['bucket']
     file_name = path_components['file']
@@ -100,9 +99,10 @@ def main(project: str, billing_project: str, url_file: str):
     input_bucket = client.get_bucket(bucket)
     blob = input_bucket.get_blob(file_name)
     if not blob:
-        raise RuntimeError(f'No file found at url_file path {url_file}')
-    blob.download_to_filename(file_name)
+        raise RuntimeError(f'No file found at url_file path {urls_file_path}')
 
+    # Download and read the file containing the links to copy into release
+    blob.download_to_filename(file_name)
     with open(file_name, 'r', encoding='ascii') as f:
         paths = [line.rstrip() for line in f]
 

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -93,7 +93,9 @@ def main(project: str, billing_project: str, url_file: str):
     path_components = get_path_components_from_gcp_path(url_file)
 
     bucket = path_components['bucket']
-    file_name = os.path.join(path_components['suffix'], path_components['file'])
+    file_name = path_components['file']
+    if path_components['suffix']:
+        file_name = os.path.join(path_components['suffix'], path_components['file'])
 
     input_bucket = client.get_bucket(bucket)
     blob = input_bucket.get_blob(file_name)

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -89,7 +89,7 @@ def main(project: str, billing_project: str, bucket: str, url_file: str):
     if not url_file.startswith(f'gs://{bucket}/'):
         raise ValueError('url_file must be a fully qualified GS path')
 
-    url_file.removeprefix(f'gs://{bucket}/')
+    url_file = url_file.removeprefix(f'gs://{bucket}/')
 
     input_bucket = client.get_bucket(bucket)
     blob = input_bucket.get_blob(url_file)

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -77,7 +77,7 @@ def main(project: str, billing_project: str, bucket: str, url_file: str):
     project :   a metamist project name, optional as it can be pulled from the AR config
     billing_project :    a GCP project ID to bill to
     bucket :    the GCP bucket containing the data to copy
-    urls :   a full GS path to a file containing the links to move into the release bucket
+    url_file :   a full GS path to a file containing the links to move into the release bucket
     """
     if not project:
         config = get_config()
@@ -92,7 +92,10 @@ def main(project: str, billing_project: str, bucket: str, url_file: str):
     url_file.removeprefix(f'gs://{bucket}/')
 
     input_bucket = client.get_bucket(bucket)
-    input_bucket.get_blob(url_file).download_to_filename(url_file)
+    blob = input_bucket.get_blob(url_file)
+    if not blob:
+        raise RuntimeError(f'No file found at url_file path {url_file}')
+    blob.download_to_filename(url_file)
 
     with open(url_file, 'r', encoding='ascii') as f:
         paths = f.readlines()

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+"""
+Given a project, billing-project ID, bucket, and path to a
+file containing urls, copies all the urls from the file into
+the project's release bucket.
+"""
+
+import logging
+import sys
+import subprocess
+import time
+import click
+
+from google.cloud import storage
+
+# pylint: disable=E0401,E0611
+from cpg_utils.config import get_config
+
+client = storage.Client()
+
+
+def check_paths_exist(paths: list[str]):
+    """
+    Checks a list of gs:// paths to see if they point to an existing blob
+    Logs the invalid paths if any are found
+    """
+    invalid_paths = False
+    for path in paths:
+        # gsutil ls <path> returns '<path>\n' if path exists
+        result = subprocess.run(
+            ['gsutil', 'ls', path], check=True, capture_output=True, text=True
+        ).stdout.strip('\n')
+        if result == path:
+            continue
+        # If path does not exist, log the path and set invalid_paths to True
+        logging.info(f'Invalid path: {path}')
+        invalid_paths = True
+
+    if invalid_paths:
+        return False
+    return True
+
+
+def copy_to_release(project: str, billing_project: str, paths: list[str]):
+    """
+    Copy many files from main bucket paths to the release bucket with todays date as directory
+    """
+    today = time.strftime('%Y-%m-%d')
+    release_path = f'gs://cpg-{project}-release/{today}/'
+
+    subprocess.run(
+        [
+            'gcloud',
+            'storage',
+            '--billing-project',
+            billing_project,
+            'cp',
+            *paths,
+            release_path,
+        ],
+        check=True,
+    )
+    logging.info(f'Copied {paths} into {release_path}')
+
+
+@click.command()
+@click.option('--project', '-p', help='Metamist name of the project', default='')
+@click.option('--billing-project', '-b', help='The GCP billing project to use')
+@click.option('--bucket', help='e.g.: cpg-dataset-main-upload')
+@click.argument(
+    'url_file', help='Full GSPath to a text file containing one URL per line'
+)
+def main(project: str, billing_project: str, bucket: str, url_file: str):
+    """
+
+    Parameters
+    ----------
+    project :   a metamist project name, optional as it can be pulled from the AR config
+    billing_project :    a GCP project ID to bill to
+    bucket :    the GCP bucket containing the data to copy
+    urls :   a path to a file containing the links to move into the release bucket
+    """
+    if not project:
+        config = get_config()
+        project = config['workflow']['dataset']
+
+    if not billing_project:
+        billing_project = project
+
+    if not url_file.startswith(f'gs://{bucket}/'):
+        raise ValueError('url_file must be a fully qualified GS path')
+
+    url_file.removeprefix(f'gs://{bucket}/')
+
+    input_bucket = client.get_bucket(bucket)
+    input_bucket.get_blob(url_file).download_to_filename(url_file)
+
+    with open(url_file, 'r', encoding='ascii') as f:
+        paths = f.readlines()
+
+    # Check if all paths are valid and execute the copy commands if they are
+    if check_paths_exist(paths):
+        copy_to_release(project, billing_project, paths)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+        datefmt='%Y-%M-%d %H:%M:%S',
+        stream=sys.stderr,
+    )
+
+    main()  # pylint: disable=no-value-for-parameter

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -92,10 +92,10 @@ def main(project: str, billing_project: str, url_file: str):
 
     path_components = get_path_components_from_gcp_path(url_file)
 
-    bucket_name = path_components['bucket_name']
+    bucket = path_components['bucket']
     file_name = os.path.join(path_components['subdir'], path_components['file'])
 
-    input_bucket = client.get_bucket(bucket_name)
+    input_bucket = client.get_bucket(bucket)
     blob = input_bucket.get_blob(file_name)
     if not blob:
         raise RuntimeError(f'No file found at url_file path {url_file}')

--- a/scripts/copy_files_to_release.py
+++ b/scripts/copy_files_to_release.py
@@ -68,9 +68,7 @@ def copy_to_release(project: str, billing_project: str, paths: list[str]):
 @click.option('--project', '-p', help='Metamist name of the project', default='')
 @click.option('--billing-project', '-b', help='The GCP billing project to use')
 @click.option('--bucket', help='e.g.: cpg-dataset-main-upload')
-@click.argument(
-    'url_file', help='Full GSPath to a text file containing one URL per line'
-)
+@click.argument('url_file')
 def main(project: str, billing_project: str, bucket: str, url_file: str):
     """
 
@@ -79,7 +77,7 @@ def main(project: str, billing_project: str, bucket: str, url_file: str):
     project :   a metamist project name, optional as it can be pulled from the AR config
     billing_project :    a GCP project ID to bill to
     bucket :    the GCP bucket containing the data to copy
-    urls :   a path to a file containing the links to move into the release bucket
+    urls :   a full GS path to a file containing the links to move into the release bucket
     """
     if not project:
         config = get_config()


### PR DESCRIPTION
This is a script which borrows a lot from the copy_sample_cram_to_release script. Reason we need a new script is because some collaborators aren't happy with receiving just CRAMs, they want the original fastq files. 

The idea here is that you create a .txt file containing the URLs of all the files you want to copy to the release bucket. 
Then, you upload this file into a bucket and specify its path in the argument to this script.

The txt file will then be downloaded onto the Hail disk, where it reads the URLs and executes copy commands on all the files into a directory with today's date in the release bucket.

One thing I'm unsure about is the text file encoding. I created a test .txt file in vscode and it defaulted to 'us-ascii' encoding, but I'm not sure if this is generally applicable. Is there a better practice?