### PR TITLE
Collected minor fixes

### DIFF
--- a/dataproc/init_scripts/install_common.sh
+++ b/dataproc/init_scripts/install_common.sh
@@ -32,11 +32,11 @@ pip3 install \
     gcsfs \
     pyarrow \
     sample-metadata \
-    selenium>=3.8.0 \
+    'selenium>=3.8.0' \
     statsmodels \
-    cloudpathlib[all] \
+    'cloudpathlib[all]' \
     gnomad \
-    cryptography==38.0.4
+    'cryptography==38.0.4'
 
 # Install phantomjs with a workaround for the libssl_conf.so on Debian Buster:
 # https://github.com/bazelbuild/rules_closure/issues/351#issuecomment-854628326

--- a/driver/README.md
+++ b/driver/README.md
@@ -13,7 +13,7 @@ docker build -f Dockerfile.base --tag=$DOCKER_IMAGE . && docker push $DOCKER_IMA
 
 ## `hail`
 
-The [`hail`](Dockerfile.hail) image adds Hail support and is used by default in the analysis-runner and gets built and pushed automatically as part of the [Hail update workflow](../.github/workflows/hail_update.yaml).  It also contains the cpg-utils, analysis-runner and sample-metadata packages.
+The [`hail`](Dockerfile.hail) image adds Hail support and is used by default in the analysis-runner and gets built and pushed automatically as part of the [Hail update workflow](../.github/workflows/deploy_server.yaml).  It also contains the cpg-utils, analysis-runner and sample-metadata packages.
 
 ## `r`
 

--- a/server/README.md
+++ b/server/README.md
@@ -25,7 +25,7 @@ for details.
 Download a JSON key for the `analysis-runner-server` service account. Store the file name in the `$GSA_KEY_FILE` environment variable. Then run:
 
 ```bash
-docker build -t analysis-runner-server .
+docker build -t analysis-runner-server --build-arg DRIVER_IMAGE[=...] .
 
 docker run -it -p 8080:8080 -v $GSA_KEY_FILE:/gsa-key/key.json -e GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json -e DRIVER_IMAGE=$DRIVER_IMAGE analysis-runner-server
 ```


### PR DESCRIPTION
A few items of trivia, mostly documentation, that I noticed while looking into the dataproc issue on Monday:

* Quote anything with (potential) shell metacharacters.

    This one has an effect on the startup script: pip output goes to wherever the log goes instead of accidentally being diverted to a file named `=3.8.0`. Happily there was probably no change to the package versions actually selected in all three changed lines.

* hail_update.yaml was renamed in PR #356.

* server/Dockerfile uses `${DRIVER_IMAGE}`; I'm not sure where that's intended to be set, but in any case it needs to be transmitted to the build via `--build-arg` so this is a reminder of that.