### PR TITLE
Add metamist to driver image

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -46,5 +46,6 @@ RUN apt-get update && \
         hail \
         pyarrow \
         sample-metadata \
+        metamist \
         selenium>=3.8.0 \
         statsmodels


### PR DESCRIPTION
Add metamist, leave sample-metadata temporarily until the SG deploy has been completed.
Rebuilding this image will update metamist if we need to, but as long as tests are running, we should be okay.