### PR TITLE
Fixed syntax in job command executing python script

### DIFF
--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -107,10 +107,10 @@ def main(search_path: str):
         job.command('cd /io')
         job.command(
             f"""
-            python3 {UNZIP_SCRIPT}
-                --bucket {bucket_name}
-                --subdir {subdir}
-                --blob_name {blobname}
+            python3 {UNZIP_SCRIPT} \
+                --bucket {bucket_name} \
+                --subdir {subdir} \
+                --blob_name {blobname} \
                 --outdir {output_dir}
         """
         )


### PR DESCRIPTION
Correcting the command line arguments with line continuation backslashes