### PR TITLE
Update untar script with cpg_utils import changes

### DIFF
--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -14,10 +14,13 @@ import sys
 import click
 from google.cloud import storage
 
-from cpg_workflows.batch import get_batch
 from cpg_utils.config import get_config
 from cpg_utils.git import prepare_git_job
-from cpg_utils.hail_batch import authenticate_cloud_credentials_in_job, copy_common_env
+from cpg_utils.hail_batch import (
+    authenticate_cloud_credentials_in_job,
+    copy_common_env,
+    get_batch,
+)
 
 
 CLIENT = storage.Client()


### PR DESCRIPTION
Lucky number 666... 

Replaces the `cpg_workflows.batch.get_batch` import with `cpg_utils.hail_batch.get_batch` in the untar script wrapper.