### PR TITLE
Revert Dockerfile CMD notation change

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED True
+ENV PORT 8080
+
 WORKDIR /opt/app
 
 COPY requirements.txt ./
@@ -8,4 +10,7 @@ RUN pip3 install --no-cache-dir --no-deps -r requirements.txt
 
 COPY main.py ./
 
-CMD ["exec", "gunicorn", "--bind", ":$PORT", "--workers", "1", "--threads", "8", "--timeout", "0", "main:app"]
+# we use an environment varaible to set the port,
+# so we can't use the JSON notation for the CMD
+# hadolint ignore=DL3025
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app


### PR DESCRIPTION
Introduced in #667, but I didn't know you couldn't use an environment variable in the JSON formed command, IMO, this is hadolint leading me astray.