### PR TITLE
Stream as bytes, not text

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -109,7 +109,7 @@ def handler(  # noqa: C901
         return abort(404, 'File was not found')
 
     # Stream the response to allow large files to be served.
-    response = Response(stream_with_context(blob.open('rt')))
+    response = Response(stream_with_context(blob.open('rb')))
     response.headers['Content-Type'] = (
         mimetypes.guess_type(filename)[0] or 'application/octet-stream'
     )


### PR DESCRIPTION
I initially had a check if mime_type is text, but it actually doesn't seem to matter how it's streamed if we report the type 🤷 

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1712037069724749 (streaming a PDF to through the PDF, a non-utf8 type)