### PR TITLE
Fix metamist keys for ar-integration

### DIFF
--- a/sample_metadata/README.md
+++ b/sample_metadata/README.md
@@ -8,7 +8,7 @@ To deploy, run:
 gcloud config set project analysis-runner
 
 gcloud functions deploy sample_metadata \
-     --runtime python37 \
+     --runtime python311 \
      --region australia-southeast1 \
      --trigger-topic submissions \
      --service-account sample-metadata@analysis-runner.iam.gserviceaccount.com

--- a/sample_metadata/main.py
+++ b/sample_metadata/main.py
@@ -8,6 +8,7 @@ in the Sample-Metadata database.
 import base64
 import json
 from typing import Any, Dict, Literal
+from urllib.parse import urlencode
 
 import requests
 
@@ -57,7 +58,7 @@ def sample_metadata(data: Dict[Literal['data'], str], unused_context: Any):
         'submitting_user': user,
         'output_path': output_prefix,
     }
-    q = '&'.join([f'{k}={v}' for k, v in query_params.items()])
+    q = urlencode(query_params)
 
     try:
         token = get_identity_token()

--- a/sample_metadata/main.py
+++ b/sample_metadata/main.py
@@ -29,18 +29,19 @@ def sample_metadata(data: Dict[Literal['data'], str], unused_context: Any):
     commit = metadata.pop('commit')
     script = metadata.pop('script')
     description = metadata.pop('description')
-    output_prefix = metadata.pop('outputPrefix')
+    output_prefix = metadata.pop('output')
     driver_image = metadata.pop('driverImage')
     config_path = metadata.pop('configPath')
     cwd = metadata.pop('cwd')
     environment = metadata.pop('environment')
     hail_version = metadata.pop('hailVersion', None)
     batch_url = metadata.pop('batch_url', None)
+    meta = metadata.pop('meta', {}) or {}
 
     if access_level == 'test':
         project += '-test'
 
-    sm_data = {
+    query_params = {
         'ar_guid': ar_guid,
         'access_level': access_level,
         'repository': repo,
@@ -54,15 +55,15 @@ def sample_metadata(data: Dict[Literal['data'], str], unused_context: Any):
         'hail_version': hail_version,
         'batch_url': batch_url,
         'submitting_user': user,
-        'meta': metadata,  # any remaining keys
         'output_path': output_prefix,
     }
+    q = '&'.join([f'{k}={v}' for k, v in query_params.items()])
 
     try:
         token = get_identity_token()
         r = requests.put(
-            f'{AUDIENCE}/api/v1/analysis-runner/{project}/',
-            json=sm_data,
+            f'{AUDIENCE}/api/v1/analysis-runner/{project}/?' + q,
+            json=meta,
             headers={'Authorization': f'Bearer {token}'},
             timeout=60,
         )


### PR DESCRIPTION
Params are passed as query params, which I don't love, but it's easier to change it here than create a model to capture it on metamist.

For reference:

1. analysis-runner puts a message with meta on a pubsub queue
2. This function takes that message off the queue, and puts it into metamist