### PR TITLE
Environment Lock

### DIFF
--- a/.github/workflows/copy_dataproc_init_scripts.yaml
+++ b/.github/workflows/copy_dataproc_init_scripts.yaml
@@ -22,7 +22,7 @@ jobs:
       name: "Authenticate to Google Cloud"
       uses: google-github-actions/auth@v2
       with:
-        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/gh-pool/providers/gh-provider"
+        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
         service_account: "server-deploy@analysis-runner.iam.gserviceaccount.com"
 
     - id: "google-cloud-sdk-setup"

--- a/.github/workflows/deploy_server.yaml
+++ b/.github/workflows/deploy_server.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy_server:
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
@@ -46,7 +46,7 @@ jobs:
       name: "Authenticate to Google Cloud"
       uses: google-github-actions/auth@v2
       with:
-        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/gh-pool/providers/gh-provider"
+        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
         service_account: "server-deploy@analysis-runner.iam.gserviceaccount.com"
 
     - id: "google-cloud-sdk-setup"

--- a/.github/workflows/deploy_web_server.yaml
+++ b/.github/workflows/deploy_web_server.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   deploy_server:
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
@@ -23,7 +23,7 @@ jobs:
       name: "Authenticate to Google Cloud"
       uses: google-github-actions/auth@v2
       with:
-        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/gh-pool/providers/gh-provider"
+        workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
         service_account: "server-deploy@analysis-runner.iam.gserviceaccount.com"
 
     - id: "google-cloud-sdk-setup"


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers. This change will also implement the use of environments to ensure deployments are going through the right channels.

## Changes
- [x]  Updated the workflow to use WIP
- [x]  Added `environment` attribute to the `deploy_*.yaml` files