### PR TITLE
Update Dockerfile.hail due to Hail 0.2.132 switching from raw setup.py to module build

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -19,6 +19,7 @@ RUN apt-get update && \
         software-properties-common && \
     rm -r /var/lib/apt/lists/* && \
     rm -r /var/cache/apt/* && \
+    pip --no-cache-dir install build && \
     # Install phantomjs with a workaround for libssl_conf.so:
     # https://github.com/bazelbuild/rules_closure/issues/351#issuecomment-854628326
     cd /opt && \


### PR DESCRIPTION
The build module is not installed by default on our image, so we need to install it explicitly for the /usr/local/bin/python3.10 in use (hence a Debian package would not be applicable).

See the [previous log file](https://productionresultssa12.blob.core.windows.net/actions-results/b8432886-5a71-4bc1-97d4-c57b783a4a0a/workflow-job-run-f1aa8953-b54d-5a9c-a80e-b7849fd811fe/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-07-11T03%3A11%3A33Z&sig=GDnvo72kmUChyFC7L6z5shwuCgF%2BhZBBv89%2F6p30g88%3D&ske=2024-07-11T11%3A55%3A18Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-07-10T23%3A55%3A18Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2023-11-03&sp=r&spr=https&sr=b&st=2024-07-11T03%3A01%3A28Z&sv=2023-11-03):

```
2024-07-11T02:32:44.4324786Z #6 217.9 # Clear the build cache before building the wheel
2024-07-11T02:32:44.6041513Z #6 217.9 cd build/deploy; rm -rf build; python3 -m build -w
2024-07-11T02:32:44.6042750Z #6 217.9 /usr/local/bin/python3: No module named build
```