### PR TITLE
Support repo-less execution + refactor

### DIFF
--- a/server/ar.py
+++ b/server/ar.py
@@ -1,0 +1,312 @@
+# ruff: noqa: E402
+import dataclasses
+import datetime
+import json
+from shlex import quote
+
+from aiohttp import web
+from util import (
+    PUBSUB_TOPIC,
+    _get_hail_version,
+    add_environment_variables,
+    check_dataset_and_group,
+    generate_ar_guid,
+    get_analysis_runner_metadata,
+    get_and_check_cloud_environment,
+    get_and_check_commit,
+    get_and_check_image,
+    get_and_check_repository,
+    get_and_check_script,
+    get_baseline_run_config,
+    get_email_from_request,
+    get_hail_token,
+    get_server_config,
+    publisher,
+    validate_output_dir,
+    write_config,
+)
+
+import hailtop.batch as hb
+
+from cpg_utils.config import AR_GUID_NAME, update_dict
+from cpg_utils.git import guess_script_github_url_from
+from cpg_utils.hail_batch import (
+    prepare_git_job,
+    remote_tmpdir,
+    run_batch_job_and_print_url,
+)
+
+
+@dataclasses.dataclass
+class AnalysisRunnerJobArgs:
+    output: str
+    dataset: str
+    cloud_environment: str
+    access_level: str
+    description: str
+    config: dict
+
+    # repo specific things
+    repo: str | None
+    commit: str | None
+    branch: str | None
+    cwd: str | None
+
+    # job specific things
+    script: list[str]
+    image: str
+    cpu: int
+    memory: str | None
+    storage: str | None
+    environment_variables: dict | None
+    preemptible: bool
+
+    # job submission
+    hail_token: str
+    gcp_project: str
+
+    def is_test(self) -> bool:
+        return self.access_level == 'test'
+
+    def get_batch_attributes(self) -> dict:
+        attributes = {}
+        if self.repo and self.commit:
+            attributes['repo'] = self.repo
+            attributes['commit'] = self.commit
+        if self.branch:
+            attributes['branch'] = self.branch
+
+        return attributes
+
+    def get_batch_comments(self) -> list[str]:
+        comments = []
+        if self.branch:
+            comments.append(f'BRANCH: {self.branch}')
+
+        if self.repo and self.commit:
+            script_url = guess_script_github_url_from(
+                repo=self.repo,
+                commit=self.commit,
+                script=self.script,
+                cwd=self.cwd,
+            )
+            if script_url:
+                comments.append(f'URL: {script_url}')
+
+        return comments
+
+
+def add_analysis_runner_routes(routes: web.RouteTableDef):
+    """Add cromwell route(s) to 'routes' flask API"""
+
+    @routes.post('/')
+    async def index(request: web.Request) -> web.Response:
+        """Main entry point, responds to the web root."""
+
+        email = get_email_from_request(request)
+        # When accessing a missing entry in the params dict, the resulting KeyError
+        # exception gets translated to a Bad Request error in the try block.
+        params = await request.json()
+
+        ar_guid = generate_ar_guid()
+        server_config = get_server_config()
+        job_config = prepare_inputs_from_request_json(
+            params,
+            email=email,
+            server_config=server_config,
+        )
+
+        hail_bucket = f'cpg-{job_config.dataset}-hail'
+        backend = hb.ServiceBackend(
+            billing_project=job_config.dataset,
+            remote_tmpdir=remote_tmpdir(hail_bucket),
+            token=job_config.hail_token,
+        )
+
+        # This metadata dictionary gets stored in the metadata bucket, at the output_dir location.
+        hail_version = await _get_hail_version(environment=job_config.cloud_environment)
+        timestamp = datetime.datetime.now().astimezone().isoformat()
+
+        # Prepare the job's configuration and write it to a blob.
+
+        run_config = get_baseline_run_config(
+            ar_guid=ar_guid,
+            environment=job_config.cloud_environment,
+            gcp_project_id=job_config.gcp_project,
+            dataset=job_config.dataset,
+            access_level=job_config.access_level,
+            output_prefix=job_config.output,
+            driver=job_config.image,
+        )
+        if user_config := job_config.config:  # Update with user-specified configs.
+            update_dict(run_config, user_config)
+
+        config_path = write_config(
+            ar_guid=ar_guid,
+            config=run_config,
+            environment=job_config.cloud_environment,
+        )
+
+        user_name = email.split('@')[0]
+        job_provenance = job_config.image
+        if job_config.repo:
+            job_provenance = f'{job_config.repo}:{job_config.commit}'
+
+        batch_name = f'{user_name} {job_provenance}/{" ".join(job_config.script)}'
+
+        metadata = get_analysis_runner_metadata(
+            ar_guid=ar_guid,
+            name=batch_name,
+            timestamp=timestamp,
+            dataset=job_config.dataset,
+            user=email,
+            access_level=job_config.access_level,
+            repo=job_config.repo,
+            commit=job_config.commit,
+            script=' '.join(job_config.script),
+            description=job_config.description,
+            output_prefix=job_config.output,
+            hailVersion=hail_version,
+            driver_image=job_config.image,
+            config_path=config_path,
+            cwd=job_config.cwd,
+            environment=job_config.cloud_environment,
+        )
+
+        extra_batch_params = {}
+
+        if job_config.cloud_environment == 'gcp':
+            extra_batch_params['requester_pays_project'] = job_config.gcp_project
+
+        attributes = {
+            AR_GUID_NAME: ar_guid,
+            'author': user_name,
+        }
+
+        batch = hb.Batch(
+            backend=backend,
+            name=batch_name,
+            **extra_batch_params,
+            attributes=attributes,
+        )
+
+        url = run_batch_job_and_print_url(
+            batch,
+            wait=params.get('wait', False),
+            environment=job_config.cloud_environment,
+        )
+
+        # Publish the metadata to Pub/Sub.
+        metadata['batch_url'] = url
+        publisher.publish(PUBSUB_TOPIC, json.dumps(metadata).encode('utf-8')).result()
+
+        return web.Response(text=f'{url}/jobs/1\n')
+
+
+def prepare_inputs_from_request_json(
+    params: dict,
+    email: str,
+    server_config: dict,
+) -> AnalysisRunnerJobArgs:
+    output_prefix = validate_output_dir(params['output'])
+    dataset = params['dataset']
+    access_level = params['accessLevel']
+
+    cloud_environment = get_and_check_cloud_environment(params)
+
+    dataset_config = check_dataset_and_group(
+        server_config=server_config,
+        environment=cloud_environment,
+        dataset=dataset,
+        email=email,
+    )
+    environment_config = dataset_config.get(cloud_environment, {})
+
+    gcp_project_id = environment_config.get('projectId')
+
+    is_test = access_level == 'test'
+
+    repo = get_and_check_repository(params, dataset_config)
+    commit = get_and_check_commit(params, repo)
+
+    return AnalysisRunnerJobArgs(
+        dataset=dataset,
+        output=output_prefix,
+        cloud_environment=cloud_environment,
+        access_level=access_level,
+        description=params['description'],
+        config=params.get('config'),
+        # repo specific
+        repo=get_and_check_repository(params, dataset_config),
+        commit=commit,
+        branch=params.get('branch'),
+        cwd=params.get('cwd'),
+        script=get_and_check_script(params),
+        # job specific
+        image=get_and_check_image(params, is_test),
+        cpu=params.get('cpu', 1),
+        memory=params.get('memory'),
+        storage=params.get('storage'),
+        environment_variables=params.get('environmentVariables'),
+        preemptible=params.get('preemptible', True),
+        # other
+        hail_token=get_hail_token(
+            dataset=dataset,
+            environment_config=environment_config,
+            access_level=access_level,
+        ),
+        gcp_project=gcp_project_id,
+    )
+
+
+def prepare_job_from_config(
+    batch: hb.Batch,
+    job_config: AnalysisRunnerJobArgs,
+    config_path: str,
+) -> hb.batch.job.Job:
+
+    job = batch.new_job(name='driver')
+    job.env('CPG_CONFIG_PATH', config_path)
+
+    # add comments
+    comments = job_config.get_batch_comments()
+    job.command('\n'.join(f'echo {quote(comment)}' for comment in comments))
+
+    job.image(job_config.image)
+    if job_config.cpu:
+        job.cpu(job_config.cpu)
+    if job_config.storage:
+        job.storage(job_config.storage)
+    if job_config.memory:
+        job.memory(job_config.memory)
+    job._preemptible = job_config.preemptible  # noqa: SLF001
+
+    if job_config.environment_variables:
+        add_environment_variables(job, job_config.environment_variables)
+
+    if job_config.repo:
+        prepare_job_with_repo(job, job_config)
+
+    # Finally, run the script.
+    escaped_script = ' '.join(quote(s) for s in job_config.script if s)
+    job.command(escaped_script)
+
+    return job
+
+
+def prepare_job_with_repo(job: hb.batch.job.BashJob, config: AnalysisRunnerJobArgs):
+
+    if not config.repo or not config.commit:
+        raise ValueError('Internal error: missing repo or commit')
+
+    job = prepare_git_job(
+        job=job,
+        repo_name=config.repo,
+        commit=config.commit,
+        is_test=config.is_test(),
+    )
+
+    if config.cwd:
+        job.command(f'cd {quote(config.cwd)}')
+    script = config.script
+    job.command(f'which {quote(script[0])} || chmod +x {quote(script[0])}')

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,102 @@
+# ruff: noqa: E402
+import dataclasses
+import json
+
+from aiohttp import web
+from util import (
+    check_dataset_and_group,
+    get_and_check_cloud_environment,
+    get_and_check_image,
+    get_baseline_run_config,
+    get_email_from_request,
+    get_server_config,
+    validate_output_dir,
+)
+
+from cpg_utils.config import update_dict
+
+
+@dataclasses.dataclass
+class AnalysisRunnerConfigArgs:
+    dataset: str
+    output_prefix: str
+    access_level: str
+    config: dict
+    cloud_environment: str
+    image: str
+    gcp_project: str
+
+    def is_test(self) -> bool:
+        return self.access_level == 'test'
+
+
+def add_config_routes(routes: web.RouteTableDef):
+
+    @routes.post('/config')
+    async def config(request: web.Request) -> web.Response:
+        """
+        Generate CPG config, as JSON response
+        """
+        email = get_email_from_request(request)
+        # When accessing a missing entry in the params dict, the resulting KeyError
+        # exception gets translated to a Bad Request error in the try block below.
+        params = await request.json()
+
+        args = get_args_from_params(
+            params,
+            email=email,
+            server_config=get_server_config(),
+        )
+
+        # Prepare the job's configuration to return
+        run_config = get_baseline_run_config(
+            ar_guid='<generated-at-runtime>',
+            environment=args.cloud_environment,
+            gcp_project_id=args.gcp_project,
+            dataset=args.dataset,
+            access_level=args.access_level,
+            output_prefix=args.output_prefix,
+            driver=args.image,
+        )
+        if user_config := params.get('config'):  # Update with user-specified configs.
+            update_dict(run_config, user_config)
+
+        return web.Response(
+            status=200,
+            body=json.dumps(run_config).encode('utf-8'),
+            content_type='application/json',
+        )
+
+
+def get_args_from_params(
+    params: dict,
+    email: str,
+    server_config: dict,
+) -> AnalysisRunnerConfigArgs:
+
+    dataset = params['dataset']
+    output_prefix = validate_output_dir(params['output'])
+    access_level = params['accessLevel']
+    is_test = access_level == 'test'
+
+    cloud_environment = get_and_check_cloud_environment(params)
+
+    dataset_config = check_dataset_and_group(
+        server_config=server_config,
+        environment=cloud_environment,
+        dataset=dataset,
+        email=email,
+    )
+    environment_config = dataset_config.get(cloud_environment, {})
+
+    image = get_and_check_image(params, is_test=is_test)
+
+    return AnalysisRunnerConfigArgs(
+        dataset=dataset,
+        output_prefix=output_prefix,
+        access_level=access_level,
+        config=params.get('config'),
+        cloud_environment=cloud_environment,
+        image=image,
+        gcp_project=environment_config.get('projectId'),
+    )

--- a/server/main.py
+++ b/server/main.py
@@ -1,41 +1,15 @@
 """The analysis-runner server, running Hail Batch pipelines on users' behalf."""
 
 # ruff: noqa: E402
-import datetime
 import json
 import logging
 import traceback
-from shlex import quote
 
 import nest_asyncio
 from aiohttp import web
+from ar import add_analysis_runner_routes
+from config import add_config_routes
 from cromwell import add_cromwell_routes
-from util import (
-    DRIVER_IMAGE,
-    PUBSUB_TOPIC,
-    _get_hail_version,
-    check_allowed_repos,
-    check_dataset_and_group,
-    generate_ar_guid,
-    get_analysis_runner_metadata,
-    get_baseline_run_config,
-    get_email_from_request,
-    get_server_config,
-    publisher,
-    validate_image,
-    validate_output_dir,
-    write_config,
-)
-
-import hailtop.batch as hb
-
-from cpg_utils.config import AR_GUID_NAME, update_dict
-from cpg_utils.git import guess_script_github_url_from
-from cpg_utils.hail_batch import (
-    prepare_git_job,
-    remote_tmpdir,
-    run_batch_job_and_print_url,
-)
 
 # Patching asyncio *before* importing the Hail Batch module is necessary to avoid a
 # "Cannot enter into task" error.
@@ -51,274 +25,6 @@ if USE_GCP_LOGGING:
     client = google.cloud.logging.Client()
     client.get_default_handler()
     client.setup_logging()
-
-routes = web.RouteTableDef()
-
-SUPPORTED_CLOUD_ENVIRONMENTS = {'gcp'}
-
-
-@routes.post('/')
-async def index(request: web.Request) -> web.Response:  # noqa: C901
-    """Main entry point, responds to the web root."""
-
-    email = get_email_from_request(request)
-    # When accessing a missing entry in the params dict, the resulting KeyError
-    # exception gets translated to a Bad Request error in the try block below.
-    params = await request.json()
-
-    output_prefix = validate_output_dir(params['output'])
-    dataset = params['dataset']
-    cloud_environment = params.get('cloud_environment', 'gcp')
-    if cloud_environment not in SUPPORTED_CLOUD_ENVIRONMENTS:
-        raise web.HTTPBadRequest(
-            reason=f'analysis-runner does not yet support the {cloud_environment} environment',
-        )
-
-    dataset_config = check_dataset_and_group(
-        server_config=get_server_config(),
-        environment=cloud_environment,
-        dataset=dataset,
-        email=email,
-    )
-    environment_config = dataset_config.get(cloud_environment) or {}
-    repo = params['repo']
-    check_allowed_repos(dataset_config=dataset_config, repo=repo)
-
-    ar_guid = generate_ar_guid()
-    image: str = params.get('image') or DRIVER_IMAGE
-    cpu = params.get('cpu', 1)
-    memory = params.get('memory', '1G')
-
-    # defaults to no attached storage in Driver jobs
-    storage = params.get('storage', None)
-
-    preemptible = params.get('preemptible', True)
-    environment_variables = params.get('environmentVariables')
-
-    access_level = params['accessLevel']
-    is_test = access_level == 'test'
-
-    hail_token = environment_config.get(f'{access_level}Token')
-    if not hail_token:
-        raise web.HTTPBadRequest(reason=f'Invalid access level "{access_level}"')
-
-    if not validate_image(image, is_test):
-        raise web.HTTPBadRequest(reason=f'Invalid image "{image}"')
-
-    hail_bucket = f'cpg-{dataset}-hail'
-    backend = hb.ServiceBackend(
-        billing_project=dataset,
-        remote_tmpdir=remote_tmpdir(hail_bucket),
-        token=hail_token,
-    )
-
-    commit = params['commit']
-    if not commit or commit == 'HEAD':
-        raise web.HTTPBadRequest(reason='Invalid commit parameter')
-
-    cwd = params['cwd']
-    script = params['script']
-    if not script:
-        raise web.HTTPBadRequest(reason='Invalid script parameter')
-
-    if not isinstance(script, list):
-        raise web.HTTPBadRequest(reason='Script parameter expects an array')
-
-    # This metadata dictionary gets stored in the metadata bucket, at the output_dir location.
-    hail_version = await _get_hail_version(environment=cloud_environment)
-    timestamp = datetime.datetime.now().astimezone().isoformat()
-
-    # Prepare the job's configuration and write it to a blob.
-
-    run_config = get_baseline_run_config(
-        ar_guid=ar_guid,
-        environment=cloud_environment,
-        gcp_project_id=environment_config.get('projectId'),
-        dataset=dataset,
-        access_level=access_level,
-        output_prefix=output_prefix,
-        driver=image,
-    )
-    if user_config := params.get('config'):  # Update with user-specified configs.
-        update_dict(run_config, user_config)
-
-    config_path = write_config(
-        ar_guid=ar_guid,
-        config=run_config,
-        environment=cloud_environment,
-    )
-
-    user_name = email.split('@')[0]
-    batch_name = f'{user_name} {repo}:{commit}/{" ".join(script)}'
-
-    metadata = get_analysis_runner_metadata(
-        ar_guid=ar_guid,
-        name=batch_name,
-        timestamp=timestamp,
-        dataset=dataset,
-        user=email,
-        access_level=access_level,
-        repo=repo,
-        commit=commit,
-        script=' '.join(script),
-        description=params['description'],
-        output_prefix=output_prefix,
-        hailVersion=hail_version,
-        driver_image=image,
-        config_path=config_path,
-        cwd=cwd,
-        environment=cloud_environment,
-    )
-
-    extra_batch_params = {}
-
-    if cloud_environment == 'gcp':
-        extra_batch_params['requester_pays_project'] = environment_config['projectId']
-
-    attributes = {
-        AR_GUID_NAME: ar_guid,
-        'commit': commit,
-        'repo': repo,
-        'author': user_name,
-    }
-
-    branch = params.get('branch')
-    comments = []
-    if branch:
-        attributes['branch'] = branch
-        comments.append(f'BRANCH: {branch}')
-
-    script_url = guess_script_github_url_from(
-        repo=repo,
-        commit=commit,
-        script=script,
-        cwd=cwd,
-    )
-    if script_url:
-        comments.append(f'URL: {script_url}')
-
-    batch = hb.Batch(
-        backend=backend,
-        name=batch_name,
-        **extra_batch_params,
-        attributes=attributes,
-    )
-
-    job = batch.new_job(name='driver')
-    # add comments
-    job.command('\n'.join(f'echo {quote(comment)}' for comment in comments))
-
-    job = prepare_git_job(job=job, repo_name=repo, commit=commit, is_test=is_test)
-    job.image(image)
-    if cpu:
-        job.cpu(cpu)
-    if storage:
-        job.storage(storage)
-    if memory:
-        job.memory(memory)
-    job._preemptible = preemptible  # noqa: SLF001
-
-    # NOTE: Prefer using config variables instead of environment variables.
-    # In case you need to add an environment variable here, make sure to update the
-    # cpg_utils.hail_batch.copy_common_env function!
-    job.env('CPG_CONFIG_PATH', config_path)
-
-    if environment_variables:
-        if not isinstance(environment_variables, dict):
-            raise ValueError('Expected environment_variables to be dictionary')
-
-        invalid_env_vars = [
-            f'{k}={v}'
-            for k, v in environment_variables.items()
-            if not isinstance(v, str)
-        ]
-
-        if len(invalid_env_vars) > 0:
-            raise ValueError(
-                'Some environment_variables values were not strings, got '
-                + ', '.join(invalid_env_vars),
-            )
-
-        for k, v in environment_variables.items():
-            job.env(k, v)
-
-    if cwd:
-        job.command(f'cd {quote(cwd)}')
-
-    job.command(f'which {quote(script[0])} || chmod +x {quote(script[0])}')
-
-    # Finally, run the script.
-    escaped_script = ' '.join(quote(s) for s in script if s)
-    job.command(escaped_script)
-
-    url = run_batch_job_and_print_url(
-        batch,
-        wait=params.get('wait', False),
-        environment=cloud_environment,
-    )
-
-    # Publish the metadata to Pub/Sub.
-    metadata['batch_url'] = url
-    publisher.publish(PUBSUB_TOPIC, json.dumps(metadata).encode('utf-8')).result()
-
-    return web.Response(text=f'{url}/jobs/1\n')
-
-
-@routes.post('/config')
-async def config(request: web.Request) -> web.Response:
-    """
-    Generate CPG config, as JSON response
-    """
-    email = get_email_from_request(request)
-    # When accessing a missing entry in the params dict, the resulting KeyError
-    # exception gets translated to a Bad Request error in the try block below.
-    params = await request.json()
-
-    output_prefix = validate_output_dir(params['output'])
-    dataset = params['dataset']
-    cloud_environment = params.get('cloud_environment', 'gcp')
-    if cloud_environment not in SUPPORTED_CLOUD_ENVIRONMENTS:
-        raise web.HTTPBadRequest(
-            reason=f'analysis-runner config does not yet support the {cloud_environment} environment',
-        )
-
-    dataset_config = check_dataset_and_group(
-        server_config=get_server_config(),
-        environment=cloud_environment,
-        dataset=dataset,
-        email=email,
-    )
-    environment_config = dataset_config.get(cloud_environment)
-
-    image = params.get('image') or DRIVER_IMAGE
-    access_level = params['accessLevel']
-    is_test = access_level == 'test'
-
-    if not validate_image(image, is_test):
-        raise web.HTTPBadRequest(reason=f'Invalid image "{image}"')
-
-    # Prepare the job's configuration to return
-
-    run_config = get_baseline_run_config(
-        ar_guid='<generated-at-runtime>',
-        environment=cloud_environment,
-        gcp_project_id=environment_config.get('projectId'),
-        dataset=dataset,
-        access_level=access_level,
-        output_prefix=output_prefix,
-        driver=image,
-    )
-    if user_config := params.get('config'):  # Update with user-specified configs.
-        update_dict(run_config, user_config)
-
-    return web.Response(
-        status=200,
-        body=json.dumps(run_config).encode('utf-8'),
-        content_type='application/json',
-    )
-
-
-add_cromwell_routes(routes)
 
 
 def prepare_exception_json_response(
@@ -387,7 +93,13 @@ async def error_middleware(_, handler):  # noqa: ANN001
 async def init_func():
     """Initializes the app."""
     app = web.Application(middlewares=[error_middleware])
+    routes = web.RouteTableDef()
+
+    add_analysis_runner_routes(routes)
+    add_cromwell_routes(routes)
+    add_config_routes(routes)
     app.add_routes(routes)
+
     return app
 
 


### PR DESCRIPTION
- Make repo + commit optional (with use of `--skip-repo-checkout` flag)
- Refactor the server into better param extraction, and then application.
- Split `server/main.py` into `ar.py` and `config.py`