### PR TITLE
Add environment to copy-dataproc-init-script

### DIFF
--- a/.github/workflows/copy_dataproc_init_scripts.yaml
+++ b/.github/workflows/copy_dataproc_init_scripts.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   copy_init_scripts:
     runs-on: ubuntu-latest
-
+    environment: production
     steps:
     - name: "checkout repo"
       uses: actions/checkout@v4


### PR DESCRIPTION
Failing run: https://github.com/populationgenomics/analysis-runner/actions/runs/10189931589/job/28188823868
Probably hasn't been run since #685 