### PR TITLE
Hail 0.2.132 switched from raw setup.py to module build

### DIFF
--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     libopenblas-base \
     make \
     openjdk-8-jdk-headless \
+    python3-build \
     python3-pip \
     rsync \
     zip && \


### PR DESCRIPTION
Similar to the previous #689 which updated another Dockerfile similarly. This time the Dockerfile uses a system Python, so we can install the build module via Ubuntu's package.