### PR TITLE
More accumulated dataproc Dockerfile changes (and miscellanea)

### DIFF
--- a/analysis_runner/cli_cromwell.py
+++ b/analysis_runner/cli_cromwell.py
@@ -123,8 +123,8 @@ def _add_cromwell_submit_args_to(
         required=False,
         action='append',
         help=(
-            'A directory which is used to search for workflow imports. You can specify this argument multiple times.'
-            'Note: the directories are zipped from the cwd with `zip -r {directory1} {directory2}`.'
+            'A directory which is used to search for workflow imports. You can specify this argument multiple times. '
+            'Note: the directories are zipped from the cwd with `zip -r {directory1} {directory2}`. '
             'Please raise an issue to change this behaviour'
         ),
     )

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -58,4 +58,4 @@ RUN apt-get update && \
 # the `pip_dependencies` section of this yaml file, then the hail wheel won't be
 # copied over to the cluster resulting in the above error. However, remember to
 # check your error logs for the exact error message.
-RUN if [ "$STRIP_PIP_VERSIONS" == "true" ]; then sed -i '/pip_dependencies:/s/[<>=~!][^|]*//g' /usr/local/lib/python3.10/dist-packages/hailtop/hailctl/deploy.yaml; fi
+RUN if [ "$STRIP_PIP_VERSIONS" = "true" ]; then sed -i '/pip_dependencies:/s/[<>=~!][^|]*//g' /usr/local/lib/python3.10/dist-packages/hailtop/hailctl/deploy.yaml; fi

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && \
     libopenblas-base \
     make \
     openjdk-8-jdk-headless \
-    python3-build \
     python3-pip \
     python3-venv \
     rsync \
@@ -30,6 +29,7 @@ RUN apt-get update && \
     apt-get install -y google-cloud-sdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir build && \
     git clone https://github.com/populationgenomics/hail.git && \
     if [ -n "$HAIL_COMMIT" ]; then cd hail && git checkout ${HAIL_COMMIT} && cd ..; fi && \
     cd hail/hail && \

--- a/dataproc/Dockerfile
+++ b/dataproc/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
     openjdk-8-jdk-headless \
     python3-build \
     python3-pip \
+    python3-venv \
     rsync \
     zip && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/server/util.py
+++ b/server/util.py
@@ -99,8 +99,8 @@ def check_allowed_repos(dataset_config: Dict, repo: str):
     if repo not in allowed_repos:
         raise web.HTTPForbidden(
             reason=(
-                f'Repository "{repo}" is not one of the allowed repositories, you may'
-                'need add it to the repository-map: '
+                f'Repository "{repo}" is not one of the allowed repositories, you may '
+                'need to add it to the repository-map: '
                 'https://github.com/populationgenomics/cpg-infrastructure-private/blob/main/tokens/repository-map.json'
             ),
         )
@@ -124,7 +124,7 @@ def check_dataset_and_group(
     if not dataset_config:
         raise web.HTTPForbidden(
             reason=(
-                f'The dataset "{dataset}" is not present in the server config, have you'
+                f'The dataset "{dataset}" is not present in the server config, have you '
                 'added it to the repository map: '
                 'https://github.com/populationgenomics/cpg-infrastructure-private/blob/main/tokens/repository-map.json'
             ),


### PR DESCRIPTION
Further fixes that had to be applied to get a successful dataproc image build:

* It also needed `venv`.
* It turns out the Jammy `python3-build` package is old and broken (cf https://github.com/pypa/build/issues/215#issuecomment-1335839224) so we install the current version via pip instead.
* Docker I think defaults to using `dash`, so avoid a bashism to prevent the default `STRIP_PIP_VERSIONS=false` producing a (harmless) error message.

Also some unrelated string formatting miscellanea that I've had lying around in my checkout for a while.