### PR TITLE
Add workflow for deploying dataproc image

### DIFF
--- a/.github/workflows/deploy_dataproc.yaml
+++ b/.github/workflows/deploy_dataproc.yaml
@@ -45,5 +45,5 @@ jobs:
           cd dataproc
           gcloud builds submit \
             --timeout=1h \
-            --tag=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version }} \
+            --tag=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version || '0.2.132' }} \
             .

--- a/.github/workflows/deploy_dataproc.yaml
+++ b/.github/workflows/deploy_dataproc.yaml
@@ -5,9 +5,6 @@ on:
       hail_version:
         description: "Hail version"
         required: true
-  push:
-    branches:
-      - dataproc-deploy-script
 
 permissions:
   contents: read
@@ -46,7 +43,7 @@ jobs:
 
       - name: "build docker file"
         run: |
-          DOCKER_PATH=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version || '0.2.132' }}
+          DOCKER_PATH=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version }}
 
           docker build \
             --tag $DOCKER_PATH \

--- a/.github/workflows/deploy_dataproc.yaml
+++ b/.github/workflows/deploy_dataproc.yaml
@@ -5,6 +5,9 @@ on:
       hail_version:
         description: "Hail version"
         required: true
+  push:
+    branches:
+      - dataproc-deploy-script
 
 permissions:
   contents: read

--- a/.github/workflows/deploy_dataproc.yaml
+++ b/.github/workflows/deploy_dataproc.yaml
@@ -40,10 +40,16 @@ jobs:
         with:
           project_id: "analysis-runner"
 
-      - name: "deploy through gcloud build"
+      - name: "gcloud docker auth"
         run: |
-          cd dataproc
-          gcloud builds submit \
-            --timeout=1h \
-            --tag=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version || '0.2.132' }} \
-            .
+          gcloud auth configure-docker marketplace.gcr.io,australia-southeast1-docker.pkg.dev
+
+      - name: "build docker file"
+        run: |
+          DOCKER_PATH=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version || '0.2.132' }}
+
+          docker build \
+            --tag $DOCKER_PATH \
+            dataproc/
+
+          docker push $DOCKER_PATH

--- a/.github/workflows/deploy_dataproc.yaml
+++ b/.github/workflows/deploy_dataproc.yaml
@@ -1,0 +1,46 @@
+name: Deploy dataproc container
+on:
+  workflow_dispatch:
+    inputs:
+      hail_version:
+        description: "Hail version"
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy_dataproc:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      DOCKER_IMAGE: australia-southeast1-docker.pkg.dev/analysis-runner/images/dataproc
+
+    steps:
+      - name: "checkout repo"
+        uses: actions/checkout@v4
+
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: "projects/370374240567/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "server-deploy@analysis-runner.iam.gserviceaccount.com"
+
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: "analysis-runner"
+
+      - name: "deploy through gcloud build"
+        run: |
+          cd dataproc
+          gcloud builds submit \
+            --timeout=1h \
+            --tag=$DOCKER_IMAGE:hail-${{ github.event.inputs.hail_version }} \
+            .


### PR DESCRIPTION
Just noting that it deploys whatever hail `main` is, as the tag you've requested. Doesn't seem easy to link inputs together, otherwise would've been great to link the `copy_dataproc_scripts` together.