### PR TITLE
Use Trusted Publishing to upload package to PyPI

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,6 +21,10 @@ jobs:
         with:
           python-version: '3.10'
 
+      # Needed until setup-python's image contains a PEP625-compliant setuptools
+      - name: Upgrade setuptools
+        run: pip install --upgrade 'setuptools>=69.3.0'
+
       - name: Build
         run: python setup.py sdist
 
@@ -30,13 +34,30 @@ jobs:
       - name: Run tests
         run: python -m unittest test/test_analysis_runner.py
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*
+          retention-days: 2
+
+  upload_pypi:
+    needs: package
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
       # `skip_existing: true` makes sure that the package will be published
       # only when new version is created
       - name: Publish the wheel to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ github.event_name != 'pull_request' }}
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: dist/
           skip-existing: true


### PR DESCRIPTION
This uses an automatically minted short-lived token rather than needing a token like PYPI_API_TOKEN. See <https://docs.pypi.org/trusted-publishers/>. As per best practices, we separate the uploading into a separate job (which requires uploading/download artifacts to communicate between jobs) so that only the PyPI publishing step gets the credentials.

Also upgrade setuptools to a version that produces a PEP-625-compliant archive filename, i.e., `analysis_runner-*` rather than `analysis-runner-*`, which will prevent “Deprecation notice for recent source distribution upload to 'analysis-runner'” emails from PyPI. This step can be removed when the setup-python image eventually contains setuptools 69.3.0 or later (currently it has 65.5.0).