### PR TITLE
Add -p PREFIX option to zip_gcs_files.sh to shorten command lines

### DIFF
--- a/scripts/zip_gcs_files.sh
+++ b/scripts/zip_gcs_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 #
 # Zips up the specified GCS files into a new GCS zip archive.
 #
@@ -11,9 +11,30 @@
 # This will create gs://BUCKET/ZIPPATH containing the other specified
 # files. The script will need storage space for the final zip archive
 # and one localised input file at a time.
+#
+# The -p PREFIX option can be used to abbreviate similar file names
+# so that
+#
+#    scripts/zip_gcs_files.sh gs://BUCKET/ZIPPATH -p gs://BUCKET/ A B C
+#
+# processes gs://BUCKET/A, gs://BUCKET/B, and gs://BUCKET/C.
 
 zip_path="$1"
 shift
+
+prefix=
+while getopts p: opt
+do
+    case $opt in
+    p)  prefix="$OPTARG" ;;
+    ?)  echo "Usage: zip_gcs_files.sh OUTZIP [-p PREFIX] FILE..." >&2
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+set -x
 
 cd "$BATCH_TMPDIR"
 
@@ -21,8 +42,8 @@ zip_local=$(basename "$zip_path")
 
 for file_path in "$@"
 do
-    file_local=$(basename "$file_path")
-    gcloud storage cp -P "$file_path" "$file_local"
+    file_local=$(basename "$prefix$file_path")
+    gcloud storage cp -P "$prefix$file_path" "$file_local"
 
     zip -9 "$zip_local" "$file_local"
     rm "$file_local"
@@ -30,5 +51,6 @@ done
 
 gcloud storage cp "$zip_local" "$zip_path"
 
+ls -lh "$zip_local"
 md5sum "$zip_local"
 zipinfo "$zip_local"


### PR DESCRIPTION
It turns out batches using this script with lots of GCS file paths were failing to submit because the command line was too long. (Past a certain limit, Hail communicates the script to be run via a file in a temporary bucket, and the relevant bucket permissions were not set up for this for the initial analysis-runner batch.)

This adds a `-p PREFIX` option to factor out the common prefix of similar GCS paths, which effectively pushes this limit out a bit. (And sufficiently for the current task.)

Also show the size of the final zip archive alongside its MD5 checksum and listing.