### PR TITLE
Disable GCS parallel uploads in zip_gcs_files.sh

### DIFF
--- a/scripts/zip_gcs_files.sh
+++ b/scripts/zip_gcs_files.sh
@@ -49,6 +49,9 @@ do
     rm "$file_local"
 done
 
+# Avoid needing storage.objects.delete permission to clean up tmp fragments
+gcloud config set storage/parallel_composite_upload_enabled False
+
 gcloud storage cp "$zip_local" "$zip_path"
 
 ls -lh "$zip_local"


### PR DESCRIPTION
Another tweak to this script, to prevent it failing (fortunately after uploading the final zip file!) in the `standard` access level with:

```
+ gcloud storage cp foo.zip gs://cpg-bar-main-tmp/foo.zip
WARNING: Parallel composite upload was turned ON to get the best performance on
uploading large objects. If you would like to opt-out and instead
perform a normal upload, run: `gcloud config set
storage/parallel_composite_upload_enabled False` If you would like to
disable this warning, run: `gcloud config set
storage/parallel_composite_upload_enabled True` Note that with
parallel composite uploads, your object might be uploaded as a
composite object (https://cloud.google.com/storage/docs/composite-
objects), which means that any user who downloads your object will
need to use crc32c checksums to verify data integrity. gcloud storage
is capable of computing crc32c checksums, but this might pose a
problem for other clients.

Copying file://foo.zip to gs://cpg-bar-main-tmp/foo.zip
  
ERROR: HTTPError 403: bar-standard-039@hail-295901.iam.gserviceaccount.com does not have
storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete'
denied on resource (or it may not exist).
```