### PR TITLE
Cromwell status parser counts fix

### DIFF
--- a/scripts/cromwell_status_parser.py
+++ b/scripts/cromwell_status_parser.py
@@ -178,7 +178,7 @@ def copy_outputs_to_bucket(
     print(f'{dataset} :: {sg_id} :: Copying outputs summary:')
     print(f'  Destination: gs://{destination_bucket_name}/sv_evidence/\n')
     for _, output in outputs.items():
-        for _, value in output.items():
+        for value in output.values():
             if value.endswith('scramble.vcf.gz'):
                 analysis_file_sizes['scramble'] = to_path(value).stat().st_size
             elif value.endswith('wham.vcf.gz'):

--- a/scripts/cromwell_status_parser.py
+++ b/scripts/cromwell_status_parser.py
@@ -40,55 +40,129 @@ def get_workflow_metadata_from_api(workflow_id: str):
         sys.exit(1)
 
 
-def parse_workflow_status_and_outputs(json_data: dict):
+def print_parsed_workflow_summary(
+    wf_id: str,
+    sg_id: str,
+    dataset: str,
+    status_dict: dict,
+    outputs: dict,
+):
+    """Prints the execution status and outputs of the sub-workflows."""
+    print(f"\n{dataset} :: {sg_id} :: {wf_id} :: Workflow Summary:\n")
+    for subworkflow in [
+        'CollectCounts',
+        'CollectSVEvidence',
+        'Scramble',
+        'Whamg',
+        'Manta',
+    ]:
+        print(f"  {subworkflow}:")
+        if not status_dict.get(subworkflow):
+            print("    No attempts found")
+            continue
+
+        execution_status = status_dict[subworkflow]
+        if isinstance(execution_status, dict):
+            print(f"    {len(execution_status)} attempt(s):")
+            for attempt, status in execution_status.items():
+                print(f"      {attempt}: {status}")
+                continue
+        else:
+            print(f"    {execution_status}")
+            continue
+
+        if not outputs.get(subworkflow):
+            print("    No outputs found")
+            continue
+        print("    Outputs:")
+        for key, value in outputs[subworkflow].items():
+            print(f"      {key}: {value}")
+    print()
+
+
+def parse_subworkflow_status_and_outputs(
+    subworkflow: str,
+    attempts: list[dict],
+) -> tuple[dict, dict]:
+    """
+    Parse the status and outputs of a sub-workflow from the Cromwell metadata JSON.
+    """
+    status: dict = {}
+    outputs: dict[str, dict] = {}
+    subworkflow_name = subworkflow.split('.')[-1]
+    if not attempts:
+        status[subworkflow_name] = 'Not Started'
+        return status, outputs
+
+    # The attempts dict is a list of attempts, check each to recover the outputs
+    # and status of the sub-workflow. The final status is the status of the last
+    # attempt, which is the most relevant.
+    status[subworkflow_name] = {}
+    for attempt_no in range(len(attempts)):
+        assert attempts[attempt_no].get('attempt') == attempt_no + 1
+        # Get the execution status
+        execution_status = attempts[attempt_no].get('executionStatus')
+        # Check for failures
+        if 'failures' in attempts[attempt_no]:
+            execution_status = 'Failed'
+            failure_message = attempts[attempt_no]['failures'][0].get(
+                'message',
+                'Unknown failure',
+            )
+            status[subworkflow_name][
+                f'attempt {attempt_no + 1}'
+            ] = f"{execution_status}: {failure_message}"
+        else:
+            status[subworkflow_name][f'attempt {attempt_no + 1}'] = execution_status
+
+        # Get the outputs of the sub-workflow
+        outputs[subworkflow_name] = outputs.get(subworkflow_name, {})
+        if workflow_outputs := attempts[attempt_no].get('outputs', {}):
+            for output_key, output_value in workflow_outputs.items():
+                if output_value.endswith(('cram', 'crai')):
+                    continue
+                outputs[subworkflow_name][output_key] = output_value
+
+    return status, outputs
+
+
+def parse_workflow_status_and_outputs(wf_id: str, json_data: dict):
+    """
+    Parse the status and outputs of all subworkflows within a workflow from the Cromwell metadata JSON.
+    """
     sg_id = None
     dataset = None
     status = {}
     outputs: dict[str, dict] = {}
     calls = json_data.get('calls', {})
 
-    for key, value in calls.items():
+    for subworkflow, attempts in calls.items():
         # Get the dataset and sequencing group ID from the LocalizeReads sub-workflow
         # This should never be missing as it is required for all other sub-workflows
-        if key == 'GatherSampleEvidence.LocalizeReads':
-            input_reads = value[0].get('inputs', {}).get('reads_path')
+        if subworkflow == 'GatherSampleEvidence.LocalizeReads':
+            input_reads = attempts[0].get('inputs', {}).get('reads_path')
             sg_id = input_reads.split('/')[-1].split('.')[0]
             dataset = input_reads.removeprefix('gs://cpg-').rsplit('-', 1)[0]
             continue
-        if key.startswith('GatherSampleEvidence.'):
-            workflow_name = key.split('.')[-1]
-            if value:
-                # Get the execution status
-                execution_status = value[0].get('executionStatus')
-
-                # Check for failures
-                if 'failures' in value[0]:
-                    execution_status = 'Failed'
-                    failure_message = value[0]['failures'][0].get(
-                        'message',
-                        'Unknown failure',
-                    )
-                    status[workflow_name] = f"{execution_status}: {failure_message}"
-                else:
-                    status[workflow_name] = execution_status
-
-                # Get the outputs
-                outputs[workflow_name] = {}
-                if workflow_outputs := value[0].get('outputs', {}):
-                    for output_key, output_value in workflow_outputs.items():
-                        if output_value.endswith(('cram', 'crai')):
-                            continue
-                        outputs[workflow_name][output_key] = output_value
-
-            else:
-                status[workflow_name] = 'Not Started'
+        if subworkflow.startswith('GatherSampleEvidence.'):
+            subworkflow_status, subworkflow_outputs = (
+                parse_subworkflow_status_and_outputs(
+                    subworkflow,
+                    attempts,
+                )
+            )
+            status.update(subworkflow_status)
+            outputs.update(subworkflow_outputs)
 
     if not sg_id:
         raise ValueError("SG ID not found in metadata")
+    print_parsed_workflow_summary(wf_id, sg_id, dataset, status, outputs)
     return {sg_id.upper(): {'dataset': dataset, 'status': status, 'outputs': outputs}}
 
 
 def copy_outputs_to_bucket(
+    sg_id: str,
+    dataset: str,
     outputs: dict,
     source_bucket_name: str,
     destination_bucket_name: str,
@@ -101,6 +175,8 @@ def copy_outputs_to_bucket(
     source_bucket = storage_client.bucket(source_bucket_name)
     destination_bucket = storage_client.bucket(destination_bucket_name)
 
+    print(f'{dataset} :: {sg_id} :: Copying outputs summary:')
+    print(f'  Destination: gs://{destination_bucket_name}/sv_evidence/\n')
     for _, output in outputs.items():
         for _, value in output.items():
             if value.endswith('scramble.vcf.gz'):
@@ -117,19 +193,23 @@ def copy_outputs_to_bucket(
             destination_gs_url = (
                 f'gs://{destination_bucket_name}/{destination_blob_name}'
             )
-            destination_gs_url.replace('counts.tsv.gz', 'coverage_counts.tsv.gz')
+            destination_gs_url = destination_gs_url.replace(
+                'counts.tsv.gz',
+                'coverage_counts.tsv.gz',
+            )
             if not dry_run:
-                print(f'Copying {source_blob.name} to {destination_gs_url}')
+                print(f'    Copying {source_blob.name} to {destination_gs_url}')
                 blob_copy = source_bucket.copy_blob(
                     source_blob,
                     destination_bucket,
                     destination_blob_name,
                 )
-                print(f"Blob {blob_copy.name} copied")
+                print(f"    Blob {blob_copy.name} copied")
             else:
                 print(
-                    f"DRY RUN: Would have copied {source_blob.name} to {destination_gs_url}",
+                    f"    DRY RUN: Would have copied gs://{source_bucket_name}/{source_blob.name} to {destination_gs_url}",
                 )
+            print()
 
     return analysis_file_sizes
 
@@ -142,12 +222,16 @@ def get_analyses_to_create(
 ):
     """Queues the analyses to be created."""
     analyses = []
+    print(f'{dataset} :: {sg_id} :: {participant_eid} Analyses summary:\n')
     for analysis_type in ['scramble', 'wham', 'manta']:
         if analysis_file_sizes.get(analysis_type) is None:
-            print(f'No {analysis_type} outputs found for {sg_id}.')
+            print(f'  {analysis_type}: No outputs found. Skipping...')
             continue
         output_path = to_path(
             f'gs://cpg-{dataset}-main/sv_evidence/{sg_id}.{analysis_type}.vcf.gz',
+        )
+        print(
+            f'  {analysis_type}: {output_path.name} : {analysis_file_sizes[analysis_type]} bytes',
         )
         sv_analysis = Analysis(
             type='sv',
@@ -240,30 +324,22 @@ def main(dataset: list[str], workflow_id: list[str], dry_run: bool = False):
     sg_analyses_sizes = {}
     sg_datasets = {}
     sg_analyses = {}
+    print(f'Parsing {len(workflow_id)} workflows...')
     for wf_id in workflow_id:
         json_data = get_workflow_metadata_from_api(wf_id)
-        workflow_status = parse_workflow_status_and_outputs(json_data)
+        workflow_results = parse_workflow_status_and_outputs(wf_id, json_data)
 
-        sg_id = next(iter(workflow_status.keys()))
-        wf_dataset = workflow_status[sg_id]['dataset']
+        sg_id = next(iter(workflow_results.keys()))
+        wf_dataset = workflow_results[sg_id]['dataset']
         sg_datasets[sg_id] = wf_dataset
-        status = workflow_status[sg_id]['status']
-        outputs = workflow_status[sg_id]['outputs']
-
-        print(f"Workflow Status for ID {workflow_id}:")
-        print(f"  Dataset: {wf_dataset}, Sequencing Group ID: {sg_id}")
-        for workflow_name, execution_status in status.items():
-            print(f"  {workflow_name}: {execution_status}")
-        print(f'{len(outputs)} outputs found:')
-        for workflow_name, output in outputs.items():
-            print(f"  {workflow_name}:")
-            for key, value in output.items():
-                print(f"    {key}: {value}")
+        outputs = workflow_results[sg_id]['outputs']
 
         # Copy outputs to bucket
         source_bucket_name = 'cpg-seqr-main-tmp'
         destination_bucket_name = f'cpg-{wf_dataset}-main'
         analysis_file_sizes = copy_outputs_to_bucket(
+            sg_id,
+            wf_dataset,
             outputs,
             source_bucket_name,
             destination_bucket_name,
@@ -283,10 +359,10 @@ def main(dataset: list[str], workflow_id: list[str], dry_run: bool = False):
     if not dry_run:
         create_sv_analyses(sg_datasets, sg_analyses)
     else:
+        print()
         for sg_id, sg_dataset in sg_datasets.items():
-            print(f"Dataset: {sg_dataset}")
             print(
-                f"Sequencing Group ID: {sg_id}, Would create: {len(sg_analyses[sg_id])} SV analyses",
+                f"{sg_dataset} :: {sg_id} :: DRY RUN: Would have created: {len(sg_analyses[sg_id])} SV analyses",
             )
 
 

--- a/scripts/cromwell_status_parser.py
+++ b/scripts/cromwell_status_parser.py
@@ -117,6 +117,7 @@ def copy_outputs_to_bucket(
             destination_gs_url = (
                 f'gs://{destination_bucket_name}/{destination_blob_name}'
             )
+            destination_gs_url.replace('counts.tsv.gz', 'coverage_counts.tsv.gz')
             if not dry_run:
                 print(f'Copying {source_blob.name} to {destination_gs_url}')
                 blob_copy = source_bucket.copy_blob(


### PR DESCRIPTION
Fixes:
- Renames `counts.tsv.gz` to `coverage_counts.tsv.gz` - the pipeline expects the latter, not sure how this has gone unnoticed until now...
- Checks through all attempts for each subworkflow, usually multiple attempts happen due to preemption. Now, we check all attempts and try to pull any successful outputs from any attempt. 
- Logs the whole thing much more nicely.


See test run: https://batch.hail.populationgenomics.org.au/batches/591767/jobs/1