### PR TITLE
SET-502 Improve performance of analysis runner web server when loading large files

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,4 +13,4 @@ COPY main.py ./
 # we use an environment varaible to set the port,
 # so we can't use the JSON notation for the CMD
 # hadolint ignore=DL3025
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind :$PORT --workers 4 --threads 8 --timeout 0 main:app

--- a/web/main.py
+++ b/web/main.py
@@ -34,12 +34,52 @@ storage_client = google.cloud.storage.Client()
 logger = logging.getLogger('gunicorn.error')
 
 
+# These calls for server config and permissions are quite expensive
+# so cache them for a little while to avoid long load times for pages
+# with lots of subsequent requests
+@cached(cache=TTLCache(maxsize=64, ttl=60))
+def get_server_config(project_id: str):
+    server_config_raw = read_secret(project_id, 'server-config')
+    if not server_config_raw:
+        raise Exception('failed to read server-config secret')
+    return json.loads(server_config_raw)
+
+
+@cached(cache=TTLCache(maxsize=1024, ttl=60))
+def has_permission(email: str, dataset: str, access_file: str | None, bucket_name: str):
+    bucket = storage_client.bucket(bucket_name)
+
+    if is_member_in_cached_group(
+        f'{dataset}-web-access',
+        email,
+        members_cache_location=MEMBERS_CACHE_LOCATION,
+    ):
+        return True
+
+    # Second chance: if there's a '.access' file in the first subdirectory,
+    # check if the email is listed there.
+    if access_file:
+        blob = bucket.get_blob(access_file)
+        if blob is None:
+            return False
+        access_list = blob.download_as_text().lower().splitlines()
+        if email in access_list:
+            return True
+
+        logger.warning(
+            f'{email} is not in {dataset} access group or {access_file}',
+        )
+        return False
+    return False
+
+
 @app.route('/<dataset>/<path:filename>')
-def handler(  # noqa: C901
+def handler(
     dataset: Optional[str] = None,
     filename: Optional[str] = None,
 ):
     """Main entry point for serving."""
+
     if not dataset or not filename:
         logger.warning('Invalid request parameters')
         return abort(400, 'Either the dataset or filename was not present')
@@ -67,11 +107,12 @@ def handler(  # noqa: C901
     if os.path.basename(filename) == '.access':
         return abort(403, 'Unable to read .access files')
 
-    server_config_raw = read_secret(ANALYSIS_RUNNER_PROJECT_ID, 'server-config')
-    if not server_config_raw:
-        logger.exception('Failed to read server-config secret')
+    try:
+        server_config = get_server_config(ANALYSIS_RUNNER_PROJECT_ID)
+    except Exception as e:
+        logger.exception(f'Failed to read server-config secret: {e}')
         return abort(500, 'Failed to read server-config secret')
-    server_config = json.loads(server_config_raw)
+
     if dataset not in server_config:
         logger.warning(f'Invalid dataset "{dataset}"')
         return abort(403, 'Invalid dataset')
@@ -79,32 +120,16 @@ def handler(  # noqa: C901
     bucket_name = f'cpg-{dataset}-{BUCKET_SUFFIX}'
     bucket = storage_client.bucket(bucket_name)
 
-    in_web_access_group = False
-    try:
-        in_web_access_group = is_member_in_cached_group(
-            f'{dataset}-web-access',
-            email,
-            members_cache_location=MEMBERS_CACHE_LOCATION,
-        )
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f'Failed to access group membership cache: {e}')
+    access_file: str | None = None
+    split_subdir = filename.split('/', maxsplit=1)
+    if len(split_subdir) == 2 and split_subdir[0]:  # noqa: PLR2004
+        access_file = f'{split_subdir[0]}/.access'
 
-    if not in_web_access_group:
-        # Second chance: if there's a '.access' file in the first subdirectory,
-        # check if the email is listed there.
-        split_subdir = filename.split('/', maxsplit=1)
-        if len(split_subdir) == 2 and split_subdir[0]:  # noqa: PLR2004
-            access_list_filename = f'{split_subdir[0]}/.access'
-            blob = bucket.get_blob(access_list_filename)
-            if blob is None:
-                logger.warning(f'{email} is not a member of the {dataset} access group')
-                return abort(403)
-            access_list = blob.download_as_text().lower().splitlines()
-            if email not in access_list:
-                logger.warning(
-                    f'{email} is not in {dataset} access group or {access_list_filename}',
-                )
-                return abort(403)
+    if not has_permission(email, dataset, access_file, bucket_name):
+        logger.warning(
+            f'{email} is not in {dataset} access group or access list',
+        )
+        return abort(403)
 
     logger.info(f'Fetching blob gs://{bucket_name}/{filename}')
     blob = bucket.get_blob(filename)

--- a/web/requirements.in
+++ b/web/requirements.in
@@ -1,3 +1,4 @@
+cachetools~=5.3
 cpg-utils~=5.1
 cryptography~=44.0 # specified explicitly to avoid vuln: GHSA-79v4-65xg-pq4g
 flask~=3.1

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -22,7 +22,9 @@ botocore==1.31.56
     #   cpg-utils
     #   s3transfer
 cachetools==5.3.2
-    # via google-auth
+    # via
+    #   -r web/requirements.in
+    #   google-auth
 certifi==2024.7.4
     # via requests
 cffi==1.16.0


### PR DESCRIPTION
[change how AR webserver serves files to improve performance](https://github.com/populationgenomics/analysis-runner/commit/f3265bbbc534d73c1628f0b0e84a32d4d8036b45)

Previously the webserver was attempting to stream the response using
stream_with_context, but this method is intended for smallish text files
to be returned line by line. This made the webserver extremely slow to
respond with even medium size files, taking nearly a minute to serve a
32mb .wasm file.

The intent of streaming the response was to allow serving of large files
by not writing them to disk or storing in memory before returning them,
but functionally this would not have worked as it would take so long to
serve the file that it wouldn't be very useful.

This change uses a more traditional method of returning a file using
flask's `send_file` method which will read the file into memory before
responding with it. This won't allow larger-than-memory files to be
served but functionally we've never needed that option anyway.


[cache expensive network calls to improve performance](https://github.com/populationgenomics/analysis-runner/commit/14fabdeacdad2a0a0755c068bf15ddd2c95cdd06)

The webserver request handler had a couple of calls, one to load the
server config secret, and one to get the membership cache that were
relatively expensive, taking between 1 and 2 seconds each. This update
caches those calls for a short period of time so that web pages that
make many requests for small files will not have to make these expensive
network calls on each request.