### PR TITLE
Skip the dragen output key in cromwell outputs parser

### DIFF
--- a/scripts/cromwell_status_parser.py
+++ b/scripts/cromwell_status_parser.py
@@ -119,6 +119,9 @@ def parse_subworkflow_status_and_outputs(
         outputs[subworkflow_name] = outputs.get(subworkflow_name, {})
         if workflow_outputs := attempts[attempt_no].get('outputs', {}):
             for output_key, output_value in workflow_outputs.items():
+                if output_key == 'is_dragen_3_7_8':
+                    # Skip the is_dragen_3_7_8 output
+                    continue
                 if output_value.endswith(('cram', 'crai')):
                     continue
                 outputs[subworkflow_name][output_key] = output_value


### PR DESCRIPTION
New subworkflow in the GATK SV GatherSampleEvidence workflow `GatherSampleEvidence.CheckAligner` - the outputs dict for this stage contains the flag `is_dragen_3_7_8`
```
"outputs": {
    "header": "gs://cpg-dataset-main-tmp/cromwell/GatherSampleEvidence/<wfid>/call-CheckAligner/CPGXXXXXX.header.sam",
    "is_dragen_3_7_8": 0
}
```

Unfortunately, this has broken the parser as it checks the output dict values using `endswith`, which is a string method. When the output value is the int `0`, it falls over
```
AttributeError: 'int' object has no attribute 'endswith'
```

This change will explicitly skip the dragen version field of the outputs dict so that the script can continue to run. 