### PR TITLE
Replace counts with coverage_counts for the actual blob

### DIFF
--- a/scripts/cromwell_status_parser.py
+++ b/scripts/cromwell_status_parser.py
@@ -193,12 +193,12 @@ def copy_outputs_to_bucket(
             destination_blob_name = (
                 f'sv_evidence/{blob_name.split("/")[-1]}'  # Copy to sv_evidence folder
             )
-            destination_gs_url = (
-                f'gs://{destination_bucket_name}/{destination_blob_name}'
-            )
-            destination_gs_url = destination_gs_url.replace(
+            destination_blob_name = destination_blob_name.replace(
                 'counts.tsv.gz',
                 'coverage_counts.tsv.gz',
+            )
+            destination_gs_url = (
+                f'gs://{destination_bucket_name}/{destination_blob_name}'
             )
             if not dry_run:
                 print(f'    Copying {source_blob.name} to {destination_gs_url}')


### PR DESCRIPTION
Im realising this was not actually fixed by #727 - it only changed the logged path, not the actual gs blob that was written. This updates the name of the blob to `coverage_counts`, which is what it should be.