### PR TITLE
Miscellaneous Dockerfile.hail etc fixes to precipitate rebuilding the driver image

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -3,7 +3,7 @@ FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver-base:1.5
 
 ARG HAIL_SHA
 
-ENV HAIL_QUERY_BACKEND service
+ENV HAIL_QUERY_BACKEND=service
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -40,7 +40,7 @@ RUN apt-get update && \
     pip --no-cache-dir install \
         analysis-runner \
         bokeh \
-        cloudpathlib[all] \
+        'cloudpathlib[all]' \
         cpg-utils \
         cpg-workflows \
         gcsfs \
@@ -48,5 +48,6 @@ RUN apt-get update && \
         pyarrow \
         sample-metadata \
         metamist \
-        selenium>=3.8.0 \
-        statsmodels
+        'selenium>=3.8.0' \
+        statsmodels && \
+    rm -rf /root/.cache /tmp/tmp*

--- a/server/ar.py
+++ b/server/ar.py
@@ -289,7 +289,7 @@ def prepare_job_from_config(
         job.storage(job_config.storage)
     if job_config.memory:
         job.memory(job_config.memory)
-    job._preemptible = job_config.preemptible  # noqa: SLF001
+    job.spot(job_config.preemptible)
 
     if job_config.environment_variables:
         add_environment_variables(job, job_config.environment_variables)


### PR DESCRIPTION
We need to build a new driver image containing cpg-utils 5.4.1, i.e., the corrected two-argument `image_path()` as per populationgenomics/cpg-utils#185.

As an excuse to build a new image, this PR collects some miscellaneous minor fixes. Most notably, the hail build leaves 1.3Gb of cached maven, mill, and pip dependencies in `/root/.cache`, and the GCP SDK installation leaves a script in `/tmp/tmp.RANDOMHASH`.