### PR TITLE
fix(Dockerfile): Remove old libraries

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -43,11 +43,9 @@ RUN apt-get update && \
         bokeh \
         'cloudpathlib[all]' \
         cpg-utils \
-        cpg-workflows \
         gcsfs \
         hail \
         pyarrow \
-        sample-metadata \
         metamist \
         'selenium>=3.8.0' \
         statsmodels && \


### PR DESCRIPTION
Removes two libraries from the analysis-runner hail(python base) image:
- `sample-metadata`: this has been replaced by `metamist` for years, and metamist is already installed as part of this command. This combined installation will try and find versions of shared dependencies between the latest and greatest, and the deprecated old codebase still on pypi.
- `cpg-workflows`: this isn't a necessary dependency. production-pipelines workflows don't use the naked analysis-runner image, they use(d) the cpg-workflows image. We have also almost entirely migrated off that codebase, so would be using cpg-flow based workflows instead.

Fun example of why these should be removed - CPG-Flow replaces cpg-workflows, and CPG-Flow builds a docker image to test workflow logic changes. That image [here](https://github.com/populationgenomics/cpg-flow/blob/main/Dockerfile#L1) builds upon this base image, which installs its predecessor. We can test the old and busted alongside the new hotness, which is bloat, as well as potentially some misleading success/failure modes