### PR TITLE
Remove MILL_VERSION tweak as upstream hail/mill wrapper now handles this

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -34,8 +34,7 @@ RUN apt-get update && \
     cd hail && \
     # Install locally, avoiding the need for a pip package.
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
-    # Append -jvm to MILL_VERSION to avoid getting a binary mill artifact built against a too-recent glibc.
-    make install DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release MILL_VERSION=$(sed -n '/mill-version/s/.*: *//p' build.mill)-jvm && \
+    make install DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release && \
     cd ../.. && \
     rm -rf hail && \
     pip --no-cache-dir install \


### PR DESCRIPTION
The previous commit's driver build failed due to a malformed `MILL_VERSION`. Since we added `-jvm` like this the _hail/mill_ wrapper script has improved to check glibc versions itself, so it appears we no longer need to do this.

The previous commit's version bump can correspond to this change.