### PR TITLE
Temporarily install JRE 17 so we can run mill within the Hail build

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -15,10 +15,9 @@ RUN apt-get update && \
         liblapack3 \
         libopenblas0 \
         openjdk-11-jdk-headless \
+        openjdk-17-jre-headless \
         rsync \
         software-properties-common && \
-    rm -r /var/lib/apt/lists/* && \
-    rm -r /var/cache/apt/* && \
     pip --no-cache-dir install build && \
     # Install phantomjs with a workaround for libssl_conf.so:
     # https://github.com/bazelbuild/rules_closure/issues/351#issuecomment-854628326
@@ -35,6 +34,7 @@ RUN apt-get update && \
     # Install locally, avoiding the need for a pip package.
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
     make install DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release && \
+    DEBIAN_FRONTEND=noninteractive apt-get remove -y openjdk-17-jre-headless && \
     cd ../.. && \
     rm -rf hail && \
     pip --no-cache-dir install \
@@ -48,5 +48,5 @@ RUN apt-get update && \
         metamist \
         'selenium>=3.8.0' \
         statsmodels && \
-    # Delete maven/pip/etc caches and /tmp scripts used only during the build
-    rm -rf /root/.cache /tmp/tmp*
+    # Delete apt/maven/pip/etc caches and /tmp scripts used only during the build
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* /root/.cache /tmp/tmp*


### PR DESCRIPTION
Temporarily install this so `mill` will run, but remove it again afterwards so the eventual driver image is unchanged.