### PR TITLE
Remove openjdk-17-jre-headless without trace via `purge`

### DIFF
--- a/driver/Dockerfile.hail
+++ b/driver/Dockerfile.hail
@@ -34,7 +34,7 @@ RUN apt-get update && \
     # Install locally, avoiding the need for a pip package.
     # DEPLOY_REMOTE avoids a dev suffix being appended to dataproc initialization paths.
     make install DEPLOY_REMOTE=1 HAIL_BUILD_MODE=Release && \
-    DEBIAN_FRONTEND=noninteractive apt-get remove -y openjdk-17-jre-headless && \
+    DEBIAN_FRONTEND=noninteractive apt-get purge -y openjdk-17-jre-headless && \
     cd ../.. && \
     rm -rf hail && \
     pip --no-cache-dir install \


### PR DESCRIPTION
```
# dpkg -l | grep openjdk
ii  openjdk-11-jdk-headless:amd64      11.0.30+7-1~deb11u1            amd64        OpenJDK Development Kit (JDK) (headless)
ii  openjdk-11-jre-headless:amd64      11.0.30+7-1~deb11u1            amd64        OpenJDK Java runtime, using Hotspot JIT (headless)
rc  openjdk-17-jre-headless:amd64      17.0.18+8-1~deb11u1            amd64        OpenJDK Java runtime, using Hotspot JIT (headless)
```

TIL `apt-get remove` leaves config files etc behind; to make a package disappear from this list entirely, what we want is `purge`.