### PR TITLE
Update unzip wrapper script to unzip single path only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ quote-style = "single"
 # ignore pydocstyle, flake8-boolean-trap (FBT)
 select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
 
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "ERA", "EXE", "FBT", "ICN", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "UP", "YTT"]
+fixable = ["ALL"]
 
 ignore = [
     "ANN101",  # Missing type annotation for self in method
@@ -29,25 +29,21 @@ ignore = [
     "S101",    # Use of assert detected
 ]
 
-
 [tool.ruff.lint.isort]
-
 section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]
 
 [tool.ruff.lint.isort.sections]
-hail = [
-    "hail",
-    "hailtop",
-]
+hail = ["hail", "hailtop"]
+cpg = ["cpg_flow", "cpg_utils", "cpg_infra", "metamist", "analysis_runner"]
 # Adjust these for each repository, e.g., removing those that should be
 # local rather than CPG. Also fill in extend_skip below if there are any
 # subdirectories that should be ignored.
-cpg = [
-    "analysis_runner",
-    "cpg_infra",
-    "cpg_utils",
-    "cpg_workflows",
-    "gnomad",
-    "hail_scripts",
-    "metamist",
-]
+# cpg = [
+#     "analysis_runner",
+#     "cpg_infra",
+#     "cpg_utils",
+#     "cpg_workflows",
+#     "gnomad",
+#     "hail_scripts",
+#     "metamist",
+# ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,22 +12,15 @@ select = ["A", "B", "C",  "E", "F", "G", "I", "N", "Q", "S", "W", "ANN", "ARG", 
 fixable = ["ALL"]
 
 ignore = [
-    "ANN101",  # Missing type annotation for self in method
-    "ANN201",  # Missing return type annotation for public function
-    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
-    "E501",    # Line length too long
-    "E731",    # Do not assign a lambda expression, use a def
-    "E741",    # Ambiguous variable name
-    "G004",    # Logging statement uses f-string
-    "PLR0911", # Too many return statements
-    "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments to function call
-    "PLR0915", # Too many statements
-    "PLW0603", # Using the global statement to update `<VAR>` is discouraged
-    "PT018",   # Assertion should be broken down into multiple parts
-    "Q000",    # Single quotes found but double quotes preferred
-    "S101",    # Use of assert detected
+    "COM812",  # Missing trailing comma (formatter conflict)
+    "ISC001",  # Implicit string concatenation (formatter conflict)
+    "Q000",    # Handled by format.quote-style = "single"
+    "Q003",    # Handled by format.quote-style = "single"
+    "ANN101", "ANN201", "ANN401", "E501", "E731", "E741", "G004", "PLR0911", "PLR0912", "PLR0913", "PLR0915", "PLW0603", "PT018", "S101",
 ]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
 
 [tool.ruff.lint.isort]
 section-order = ["future", "standard-library", "third-party", "hail", "cpg", "first-party", "local-folder"]

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -108,7 +108,11 @@ def get_tarballs_from_path(
     required=True,
 )
 @click.option(
-    '--single-path', '-s', is_flag=True, default=False, help='Restrict unzipping to a single tar ball',
+    '--single-path',
+    '-s',
+    is_flag=True,
+    default=False,
+    help='Restrict unzipping to a single tar ball',
 )
 def main(search_path: str, single_path: bool):
     """
@@ -118,6 +122,8 @@ def main(search_path: str, single_path: bool):
         search_path (str): path to find tarballs in
         single_path (bool): whether to restrict unzipping to a single tar ball
     """
+    config = get_config()
+    output_dir = config['workflow']['output_prefix']
 
     bucket_name, subdir = get_path_components_from_path(search_path)
 
@@ -149,7 +155,7 @@ def main(search_path: str, single_path: bool):
                 --bucket {bucket_name} \
                 --subdir {subdir} \
                 --blob_name {blobname} \
-                --outdir {output_dir} # noqa: F821
+                --outdir {output_dir}
         """,
         )
 

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -138,14 +138,14 @@ def main(search_path: str, single_path: str):
         blobsize = file_path.stat().st_size
         bucket = file_path.bucket
         subdir = '/'.join(file_path.parts[2:-1])
-        blobname = file_path.name
+        blobname = f'{subdir}/{file_path.name}'
         create_job(blobname, blobsize, bucket, subdir, output_dir, driver_image)
 
     get_batch().run(wait=False)
 
 
 def create_job(blobname: str, blobsize: int, bucket_name: str, subdir: str, output_dir: str, driver_image: str):
-    
+
     job = get_batch().new_job(name=f'decompress {blobname}')
     job.image(driver_image)
     job.cpu(4)

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -7,7 +7,6 @@ wrapped to modulate the batch job storage
 
 import logging
 import os
-from pathlib import Path
 import re
 import subprocess
 import sys
@@ -15,6 +14,7 @@ import sys
 import click
 from google.cloud import storage
 
+from cpg_utils import to_path
 from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import (
     authenticate_cloud_credentials_in_job,
@@ -22,7 +22,6 @@ from cpg_utils.hail_batch import (
     get_batch,
     prepare_git_job,
 )
-from cpg_utils import Path, to_path
 
 CLIENT = storage.Client()
 RMATCH_STR = r'gs://(?P<bucket>[\w-]+)/(?P<suffix>.+)/'
@@ -61,7 +60,6 @@ def get_path_components_from_path(path: str):
 def get_tarballs_from_path(
     bucket_name: str,
     subdir: str,
-    single_path: bool,
 ) -> list[tuple[str, int]]:
     """
     Checks a gs://bucket/subdir/ path for .tar and .tar.gz files
@@ -72,21 +70,19 @@ def get_tarballs_from_path(
     """
     blob_details = []
 
-    if not single_path:
-        for blob in CLIENT.list_blobs(
-            bucket_name,
-            prefix=(subdir + '/'),
-            delimiter='/',
-        ):
-            if not blob.name.endswith(('.tar', '.tar.gz', '.tar.bz2')):
-                continue
+    for blob in CLIENT.list_blobs(
+        bucket_name,
+        prefix=(subdir + '/'),
+        delimiter='/',
+    ):
+        if not blob.name.endswith(('.tar', '.tar.gz', '.tar.bz2')):
+            continue
 
-            # image size is double and a half the tar size in GB, or 30GB
-            # whichever is larger
-            job_gb = max([30, int((blob.size // GB) * 2.5)])
+        # image size is double and a half the tar size in GB, or 30GB
+        # whichever is larger
+        job_gb = max([30, int((blob.size // GB) * 2.5)])
 
-            blob_details.append((blob.name, job_gb))
-
+        blob_details.append((blob.name, job_gb))
 
     logging.info(f'{len(blob_details)} tar files found in {subdir} of {bucket_name}')
 
@@ -122,7 +118,7 @@ def main(search_path: str, single_path: str):
     if search_path:
         bucket_name, subdir = get_path_components_from_path(search_path)
 
-        blobs = get_tarballs_from_path(bucket_name, subdir, search_path)
+        blobs = get_tarballs_from_path(bucket_name, subdir)
 
         if len(blobs) == 0:
             logging.info('Nothing to do, quitting')
@@ -131,7 +127,9 @@ def main(search_path: str, single_path: str):
         # iterate over targets, set each one off in parallel
         for blobname, blobsize in blobs:
             # create and config job
-            create_job(blobname, blobsize, bucket_name, subdir, output_dir, driver_image)
+            create_job(
+                blobname, blobsize, bucket_name, subdir, output_dir, driver_image
+            )
 
     elif single_path:
         file_path = to_path(single_path)
@@ -144,7 +142,14 @@ def main(search_path: str, single_path: str):
     get_batch().run(wait=False)
 
 
-def create_job(blobname: str, blobsize: int, bucket_name: str, subdir: str, output_dir: str, driver_image: str):
+def create_job(
+    blobname: str,
+    blobsize: int,
+    bucket_name: str,
+    subdir: str,
+    output_dir: str,
+    driver_image: str,
+):
     """
     Creates and configures a Hail Batch job to decompress a single tarball
     Sets job resources based on blob size, authenticates cloud credentials, and runs the untar script
@@ -180,6 +185,7 @@ def create_job(blobname: str, blobsize: int, bucket_name: str, subdir: str, outp
             --outdir {output_dir}
     """,
     )
+
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -7,6 +7,7 @@ wrapped to modulate the batch job storage
 
 import logging
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
@@ -14,13 +15,14 @@ import sys
 import click
 from google.cloud import storage
 
-from cpg_utils.config import get_config
+from cpg_utils.config import config_retrieve
 from cpg_utils.hail_batch import (
     authenticate_cloud_credentials_in_job,
     copy_common_env,
     get_batch,
     prepare_git_job,
 )
+from cpg_utils import Path, to_path
 
 CLIENT = storage.Client()
 RMATCH_STR = r'gs://(?P<bucket>[\w-]+)/(?P<suffix>.+)/'
@@ -68,15 +70,15 @@ def get_tarballs_from_path(
         - .tar and .tar.gz blob paths found in the subdirectory
         - the size of image to use when unpacking the tarball
     """
-    object_prefixes = ('.tar', '.tar.gz', '.tar.bz2')
     blob_details = []
+
     if not single_path:
         for blob in CLIENT.list_blobs(
             bucket_name,
             prefix=(subdir + '/'),
             delimiter='/',
         ):
-            if not blob.name.endswith(object_prefixes):
+            if not blob.name.endswith(('.tar', '.tar.gz', '.tar.bz2')):
                 continue
 
             # image size is double and a half the tar size in GB, or 30GB
@@ -84,16 +86,7 @@ def get_tarballs_from_path(
             job_gb = max([30, int((blob.size // GB) * 2.5)])
 
             blob_details.append((blob.name, job_gb))
-    else:
-        blob = CLIENT.bucket(bucket_name).get_blob(subdir)
 
-        if blob and blob.name.endswith(object_prefixes):
-            job_gb = max(30, int((blob.size / GB) * 2.5))
-            blob_details.append((blob.name, job_gb))
-        else:
-            logging.warning(
-                f'Specified path gs://{bucket_name}/{subdir} is not a valid tarball.',
-            )
 
     logging.info(f'{len(blob_details)} tar files found in {subdir} of {bucket_name}')
 
@@ -105,62 +98,76 @@ def get_tarballs_from_path(
     '--search-path',
     '-p',
     help='GCP bucket/directory to search',
-    required=True,
+    required=False,
 )
 @click.option(
     '--single-path',
     '-s',
-    is_flag=True,
-    default=False,
-    help='Restrict unzipping to a single tar ball',
+    type=str,
+    required=False,
+    help='Provide a single path to a tarball, rather than a directory.',
 )
-def main(search_path: str, single_path: bool):
+def main(search_path: str, single_path: str):
     """
     Who runs the world? main()
 
     Args:
         search_path (str): path to find tarballs in
-        single_path (bool): whether to restrict unzipping to a single tar ball
+        single_path (str): whether to restrict unzipping to a single tar ball
     """
-    config = get_config()
-    output_dir = config['workflow']['output_prefix']
+    config = config_retrieve(['workflow'])
+    output_dir = config.get('output_prefix')
+    driver_image = config.get('driver_image')
 
-    bucket_name, subdir = get_path_components_from_path(search_path)
+    if search_path:
+        bucket_name, subdir = get_path_components_from_path(search_path)
 
-    blobs = get_tarballs_from_path(bucket_name, subdir, single_path)
+        blobs = get_tarballs_from_path(bucket_name, subdir, search_path)
 
-    if len(blobs) == 0:
-        logging.info('Nothing to do, quitting')
-        sys.exit(0)
+        if len(blobs) == 0:
+            logging.info('Nothing to do, quitting')
+            sys.exit(0)
 
-    # iterate over targets, set each one off in parallel
-    for blobname, blobsize in blobs:
-        # create and config job
-        job = get_batch().new_job(name=f'decompress {blobname}')
-        job.image(get_config()['workflow']['driver_image'])
-        job.cpu(4)
-        job.storage(f'{blobsize}Gi')
-        authenticate_cloud_credentials_in_job(job)
-        copy_common_env(job)
-        prepare_git_job(
-            job,
-            organisation='populationgenomics',
-            repo_name='analysis-runner',
-            commit=get_commit_hash(),
-        )
-        job.command('cd /io')
-        job.command(
-            f"""
-            python3 {UNZIP_SCRIPT} \
-                --bucket {bucket_name} \
-                --subdir {subdir} \
-                --blob_name {blobname} \
-                --outdir {output_dir}
-        """,
-        )
+        # iterate over targets, set each one off in parallel
+        for blobname, blobsize in blobs:
+            # create and config job
+            create_job(blobname, blobsize, bucket_name, subdir, output_dir, driver_image)
+
+    elif single_path:
+        file_path = to_path(single_path)
+        blobsize = file_path.stat().st_size
+        bucket = file_path.bucket
+        subdir = '/'.join(file_path.parts[2:-1])
+        blobname = file_path.name
+        create_job(blobname, blobsize, bucket, subdir, output_dir, driver_image)
 
     get_batch().run(wait=False)
 
+
+def create_job(blobname: str, blobsize: int, bucket_name: str, subdir: str, output_dir: str, driver_image: str):
+    
+    job = get_batch().new_job(name=f'decompress {blobname}')
+    job.image(driver_image)
+    job.cpu(4)
+    job.storage(f'{blobsize}Gi')
+    authenticate_cloud_credentials_in_job(job)
+    copy_common_env(job)
+    prepare_git_job(
+        job,
+        organisation='populationgenomics',
+        repo_name='analysis-runner',
+        commit=get_commit_hash(),
+    )
+    job.command('cd /io')
+    job.command(
+        f"""
+        python3 {UNZIP_SCRIPT} \
+            --bucket {bucket_name} \
+            --subdir {subdir} \
+            --blob_name {blobname} \
+            --outdir {output_dir}
+    """,
+    )
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -145,6 +145,18 @@ def main(search_path: str, single_path: str):
 
 
 def create_job(blobname: str, blobsize: int, bucket_name: str, subdir: str, output_dir: str, driver_image: str):
+    """
+    Creates and configures a Hail Batch job to decompress a single tarball
+    Sets job resources based on blob size, authenticates cloud credentials, and runs the untar script
+
+    Args:
+        blobname (str): path to the tarball blob within the bucket
+        blobsize (int): size of the tarball in GB, used to allocate job storage
+        bucket_name (str): GCS bucket containing the tarball
+        subdir (str): subdirectory within the bucket where the tarball resides
+        output_dir (str): destination path for decompressed output
+        driver_image (str): Docker image to use for the batch job
+    """
 
     job = get_batch().new_job(name=f'decompress {blobname}')
     job.image(driver_image)

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -30,7 +30,13 @@ UNZIP_SCRIPT = os.path.join(os.path.dirname(__file__), 'untar_gz_files.py')
 
 
 def get_commit_hash():
-    return subprocess.check_output(['git', 'describe', '--always']).strip().decode()
+    return (
+        subprocess.check_output(
+            ['git', 'describe', '--always'],  # noqa: S603
+        )
+        .strip()
+        .decode()
+    )
 
 
 def get_path_components_from_path(path: str):
@@ -51,7 +57,9 @@ def get_path_components_from_path(path: str):
 
 
 def get_tarballs_from_path(
-    bucket_name: str, subdir: str, single_path: bool
+    bucket_name: str,
+    subdir: str,
+    single_path: bool,
 ) -> list[tuple[str, int]]:
     """
     Checks a gs://bucket/subdir/ path for .tar and .tar.gz files
@@ -64,7 +72,9 @@ def get_tarballs_from_path(
     blob_details = []
     if not single_path:
         for blob in CLIENT.list_blobs(
-            bucket_name, prefix=(subdir + '/'), delimiter='/'
+            bucket_name,
+            prefix=(subdir + '/'),
+            delimiter='/',
         ):
             if not blob.name.endswith(object_prefixes):
                 continue
@@ -82,7 +92,7 @@ def get_tarballs_from_path(
             blob_details.append((blob.name, job_gb))
         else:
             logging.warning(
-                f'Specified path gs://{bucket_name}/{subdir} is not a valid tarball.'
+                f'Specified path gs://{bucket_name}/{subdir} is not a valid tarball.',
             )
 
     logging.info(f'{len(blob_details)} tar files found in {subdir} of {bucket_name}')
@@ -98,7 +108,7 @@ def get_tarballs_from_path(
     required=True,
 )
 @click.option(
-    '--single-path', '-s', is_flag=True, help='Restrict unzipping to a single tar ball'
+    '--single-path', '-s', is_flag=True, default=False, help='Restrict unzipping to a single tar ball',
 )
 def main(search_path: str, single_path: bool):
     """
@@ -108,8 +118,6 @@ def main(search_path: str, single_path: bool):
         search_path (str): path to find tarballs in
         single_path (bool): whether to restrict unzipping to a single tar ball
     """
-
-    config = get_config()
 
     bucket_name, subdir = get_path_components_from_path(search_path)
 
@@ -141,7 +149,7 @@ def main(search_path: str, single_path: bool):
                 --bucket {bucket_name} \
                 --subdir {subdir} \
                 --blob_name {blobname} \
-                --outdir {output_dir}
+                --outdir {output_dir} # noqa: F821
         """,
         )
 

--- a/scripts/unzip_wrapper.py
+++ b/scripts/unzip_wrapper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: S603,S607
+# ruff: noqa: S607
 """
 wrapper script for the un-tar script
 wrapped to modulate the batch job storage
@@ -50,24 +50,40 @@ def get_path_components_from_path(path: str):
     return bucket_name, subdir
 
 
-def get_tarballs_from_path(bucket_name: str, subdir: str) -> list[tuple[str, int]]:
+def get_tarballs_from_path(
+    bucket_name: str, subdir: str, single_path: bool
+) -> list[tuple[str, int]]:
     """
     Checks a gs://bucket/subdir/ path for .tar and .tar.gz files
+    If single_path == True, only returns the first tarball found in the path, otherwise returns all tarballs found
     Returns a list of:
         - .tar and .tar.gz blob paths found in the subdirectory
         - the size of image to use when unpacking the tarball
     """
-
+    object_prefixes = ('.tar', '.tar.gz', '.tar.bz2')
     blob_details = []
-    for blob in CLIENT.list_blobs(bucket_name, prefix=(subdir + '/'), delimiter='/'):
-        if not blob.name.endswith(('.tar', '.tar.gz', '.tar.bz2')):
-            continue
+    if not single_path:
+        for blob in CLIENT.list_blobs(
+            bucket_name, prefix=(subdir + '/'), delimiter='/'
+        ):
+            if not blob.name.endswith(object_prefixes):
+                continue
 
-        # image size is double and a half the tar size in GB, or 30GB
-        # whichever is larger
-        job_gb = max([30, int((blob.size // GB) * 2.5)])
+            # image size is double and a half the tar size in GB, or 30GB
+            # whichever is larger
+            job_gb = max([30, int((blob.size // GB) * 2.5)])
 
-        blob_details.append((blob.name, job_gb))
+            blob_details.append((blob.name, job_gb))
+    else:
+        blob = CLIENT.bucket(bucket_name).get_blob(subdir)
+
+        if blob and blob.name.endswith(object_prefixes):
+            job_gb = max(30, int((blob.size / GB) * 2.5))
+            blob_details.append((blob.name, job_gb))
+        else:
+            logging.warning(
+                f'Specified path gs://{bucket_name}/{subdir} is not a valid tarball.'
+            )
 
     logging.info(f'{len(blob_details)} tar files found in {subdir} of {bucket_name}')
 
@@ -81,20 +97,23 @@ def get_tarballs_from_path(bucket_name: str, subdir: str) -> list[tuple[str, int
     help='GCP bucket/directory to search',
     required=True,
 )
-def main(search_path: str):
+@click.option(
+    '--single-path', '-s', is_flag=True, help='Restrict unzipping to a single tar ball'
+)
+def main(search_path: str, single_path: bool):
     """
     Who runs the world? main()
 
     Args:
         search_path (str): path to find tarballs in
+        single_path (bool): whether to restrict unzipping to a single tar ball
     """
 
     config = get_config()
-    output_dir = config['workflow']['output_prefix']
 
     bucket_name, subdir = get_path_components_from_path(search_path)
 
-    blobs = get_tarballs_from_path(bucket_name, subdir)
+    blobs = get_tarballs_from_path(bucket_name, subdir, single_path)
 
     if len(blobs) == 0:
         logging.info('Nothing to do, quitting')


### PR DESCRIPTION
`unzip_wrapper` in its current implementation will unzip _all_ tar balls found in a directory. This PR contains updates to this script that restricts the scope to a single gcs path. After the file path is validated and the size of the tar ball is calculated, the remainder of the script proceeds as previously except with a list of tarballs of len 1. 

This change supports team Population Genomics use cases where data are delivered and untarred sequentially, often with large delays between deliveries. 

Also includes some linting changes, as pre-commit has likely been updated since this was last pushed.  